### PR TITLE
Fixed Docker pull links/syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ You will also need an external MySQL/MariaDB Container
 
 # Installation
 
-Automated builds of the image are available on [Docker Hub](https://hub.docker.com/tiredofit/freepbx) and is the recommended method of installation.
+Automated builds of the image are available on [Docker Hub](https://hub.docker.com/r/tiredofit/freepbx) and is the recommended method of installation.
 
 
 ```bash
-docker pull hub.docker.com/tiredofit/freepbx
+docker pull tiredofit/freepbx
 ```
 
 # Quick Start


### PR DESCRIPTION
The docker pull syntax in the README no longer works. Fixed.
Also fixed the link to the Docker Hub project as the original one 404s.