### PR TITLE
Update 10-freepbx

### DIFF
--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -183,6 +183,7 @@ EOF
     fwconsole ma downloadinstall certman userman pm2 --edge
     fwconsole chown 
     fwconsole reload 
+    chown -R asterisk. /home/asterisk/.npm
     fwconsole ma downloadinstall ucp --edge
     fwconsole chown 
     fwconsole reload 


### PR DESCRIPTION
added chown asterisk for the .npm folder to fix UCP not being installed because of folder permission errors