### PR TITLE
Release 3.0 w/ Freepbx 15, Asterisk 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## pre3.0 2019-02-01 <dave at tiredofit dot ca>
+## 3.0 2019-02-06 <dave at tiredofit dot ca>
 
 This is a breaking release due to major version changes.
 If attempting to run from a previous release and system detects Asterisk 14 and FreePBX instructions will be given on how to let container operate. New installations only in the 3.x series.
@@ -7,6 +7,7 @@ If attempting to run from a previous release and system detects Asterisk 14 and 
 * Freepbx 15
 * NodeJS 11
 * Multilanguage Support
+* Many bugfixes
 * Better Debug verbosity when `DEBUG_MODE=TRUE`
 
 ## 2.13 - 2019-01-31 <dave at tiredofit dot ca>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## pre 3.0-Development 2019-01-31 <dave at tiredofit dot ca>
+
+This is a breaking release due to major version changes.
+If attempting to run from a previous release and system detects Asterisk 14 and FreePBX instructions will be given on how to let container operate. New installations only in the 3.x series.
+
+* Asterisk 16
+* Freepbx 15
+* NodeJS 11
+* Multilanguage Support
+* Better Debug verbosity when `DEBUG_MODE=TRUE`
+
 ## 2.13 - 2019-01-31 <dave at tiredofit dot ca>
 
 * Add Asterisk Version in startup step to prepare for upcoming image shift to Asterisk 16 and FreePBX 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## pre 3.0-Development 2019-01-31 <dave at tiredofit dot ca>
+## pre3.0 2019-02-01 <dave at tiredofit dot ca>
 
 This is a breaking release due to major version changes.
 If attempting to run from a previous release and system detects Asterisk 14 and FreePBX instructions will be given on how to let container operate. New installations only in the 3.x series.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiredofit/nodejs:10-debian-latest
+FROM tiredofit/nodejs:11-debian-latest
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Set Defaults
@@ -194,3 +194,8 @@ LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Files Add
    ADD install /
+
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LC_CTYPE en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,8 +194,3 @@ LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Files Add
    ADD install /
-
-ENV LANGUAGE en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LC_CTYPE en_US.UTF-8

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Dave Conroy
+Copyright (c) 2019 Dave Conroy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Dave Conroy
+Copyright (c) 2019 Dave Conroy <dave at tiredofit dot ca>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Automated builds of the image are available on [Docker Hub](https://hub.docker.c
 
 
 ```bash
-docker pull tiredofit/freepbx
+docker pull tiredofit/freepbx:14
 ```
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will build a container for [FreePBX](https://www.freepbx.org) - A Voice ove
 This Container uses [tiredofit/debian:stretch](https://hub.docker.com/r/tiredofit/debian) as a base.
         
 **If you are presently running this image when it utilized FreePBX 14 and 
-Asterisk 14 and can no longer use your image, please see [this post](https://github.com/tiredofit/docker-freepbx/issues/51)
+Asterisk 14 and can no longer use your image, please see [this post](https://github.com/tiredofit/docker-freepbx/issues/51)**
 
 
 [Changelog](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@
 
 This will build a container for [FreePBX](https://www.freepbx.org) - A Voice over IP Manager for Asterisk. Upon starting this image it will give you a turn-key PBX system for SIP calling. 
 
-* Latest release Version 14
-* Compiles and Installs Asterisk 14
+* Latest release Version 15
+* Compiles and Installs Asterisk 16
 * Choice of running embedded database or Modifies to support external MySQL Database and only require one DB.
 * Supports Data Persistence
 * Fail2Ban installed to block brute force attacks
 * Debian Stretch Base w/ Apache2
-* NodeJS 8.x
+* NodeJS 11.x
 * Automatically Installs User Control Panel and displays at first page
 * Option to Install [Flash Operator Panel 2](https://www.fop2.com/)
 * Customizable FOP and Admin URLs
 
-        
 This Container uses [tiredofit/debian:stretch](https://hub.docker.com/r/tiredofit/debian) as a base.
+        
+**If you are presently running this image when it utilized FreePBX 14 and 
+Asterisk 14 and can no longer use your image, please see [this post](https://github.com/tiredofit/docker-freepbx/issues/51)
 
 
 [Changelog](CHANGELOG.md)
@@ -55,7 +57,7 @@ Companion @
 https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) 
 in order to serve your pages. However, it will run just fine on it's own if you map appropriate ports.
 
-You will also need an external MySQL/MariaDB Container
+You will also need an external MySQL/MariaDB Container, athough it can use an internally provided service (not recommended).
 
 # Installation
 
@@ -63,8 +65,13 @@ Automated builds of the image are available on [Docker Hub](https://hub.docker.c
 
 
 ```bash
-docker pull tiredofit/freepbx:14
+docker pull tiredofit/freepbx:(imagetag)
 ```
+The following image tags are available:
+
+* `15` - Asterisk 16, Freepbx 16 - Debian Stretch
+* `14` - Asterisk 14, Freepbx 14 - Debian Stretch
+* `latest` - Asterisk 16, Freepbx 16 - Debian Stretch
 
 # Quick Start
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   freepbx-app:
     container_name: freepbx-app
-    image: tiredofit/freepbx
+    image: tiredofit/freepbx:14
     ports:
      #### If you aren't using a reverse proxy
      #- 80:80

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   freepbx-app:
     container_name: freepbx-app
-    image: tiredofit/freepbx:15-latest
+    image: tiredofit/freepbx
     ports:
      #### If you aren't using a reverse proxy
      #- 80:80

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   freepbx-app:
     container_name: freepbx-app
-    image: tiredofit/freepbx:14
+    image: tiredofit/freepbx:15-latest
     ports:
      #### If you aren't using a reverse proxy
      #- 80:80

--- a/install/etc/cont-init.d/09-mariadb
+++ b/install/etc/cont-init.d/09-mariadb
@@ -1,5 +1,18 @@
 #!/usr/bin/with-contenv bash
 
+silent() {
+  if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ];  then
+    "$@"
+  else
+    "$@" > /dev/null 2>&1
+  fi
+}
+
+ ### Set Debug Mode
+ if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ]; then
+    set -x
+ fi
+
  ## Embedded DB Variance
   if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
      DB_EMBEDDED=TRUE
@@ -8,7 +21,7 @@
   fi
 
   if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then 
-  service mysql stop
+  silent service mysql stop
   mkdir -p /var/lib/mysql
 
      if [ ! -d /var/lib/mysql/mysql ]; then
@@ -17,7 +30,7 @@
      fi
 
   chown -R mysql:mysql /var/lib/mysql 
-  service mysql start
+  silent service mysql start
 fi
 
   mkdir -p /tmp/state

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -205,8 +205,8 @@ EOF
   echo '** [freepbx] Enabling Default Modules'
   echo '** [freepbx] Module Install: framework, core'
   silent fwconsole ma downloadinstall framework core 
-  silent fwconsole ma download cdr
-
+  fwconsole ma download cdr
+  
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then   
     # CDR Hack
     mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT $DB_NAME < /usr/src/freepbx/installlib/SQL/cdr.sql

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -150,7 +150,7 @@ EOF
 
     cd /usr/src
     mkdir -p /usr/src/freepbx
-    silent curl -ssL http://mirror.freepbx.org/modules/packages/freepbx/freepbx-15.0-latest.tgz | tar xfz - --strip 1 -C /usr/src/freepbx
+    curl -ssL http://mirror.freepbx.org/modules/packages/freepbx/freepbx-15.0-latest.tgz | tar xfz - --strip 1 -C /usr/src/freepbx
     cd /usr/src/freepbx
     cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
     touch /etc/asterisk/{modules,cdr}.conf
@@ -168,12 +168,12 @@ EOF
     sed -i -e "s/\$amp_conf\['CDRDBNAME'\] : 'asteriskcdrdb',/\$amp_conf\['CDRDBNAME'\] : '$DB_NAME',/g" /usr/src/freepbx/amp_conf/htdocs/admin/bootstrap.php
   fi
   
-  echo '** [freepbx] Installing FreePBX'
+  echo '** [freepbx] Installing FreePBX source code'
 
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then  
-    ./install -n --dbuser=$DB_USER --dbpass=$DB_PASS --dbname=$DB_NAME --cdrdbname=$DB_NAME --webroot=$WEBROOT
+    silent ./install -n --dbuser=$DB_USER --dbpass=$DB_PASS --dbname=$DB_NAME --cdrdbname=$DB_NAME --webroot=$WEBROOT
   else
-    ./install -n --webroot=$WEBROOT
+    silent ./install -n --webroot=$WEBROOT
   fi
 
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then 
@@ -243,7 +243,7 @@ EOF
   if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then     
       ### FOP2 Installation
       mkdir -p /data/usr/local/fop2
-      curl -ssL http://download.fop2.com/install_fop2.sh | bash
+      silent curl -ssL http://download.fop2.com/install_fop2.sh | bash
       silent service apache2 stop
       silent service fop2 stop
       chown -R asterisk. /usr/local/fop2/

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -220,8 +220,8 @@ EOF
     mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT $DB_NAME < /usr/src/freepbx/installlib/SQL/cdr.sql
     mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; UPDATE freepbx_settings SET `value` = "'$DB_HOST'" WHERE keyword = "CDRDBHOST"; UPDATE freepbx_settings SET `value` = "'$DB_NAME'" WHERE keyword = "CDRDBNAME"; UPDATE freepbx_settings SET `value` = "'$DB_PASS'" WHERE keyword = "CDRDBPASS"; UPDATE freepbx_settings SET `value` = "'$DB_USER'" WHERE keyword = "CDRDBUSER"; UPDATE freepbx_settings SET `value` = "mysql" WHERE keyword = "CDRDBTYPE"; UPDATE freepbx_settings SET `value` = "'$DB_PORT'" WHERE keyword = "CDRDBPORT"; UPDATE freepbx_settings SET `value` = "cdr" WHERE keyword = "CDRDBTABLENAME";'
     cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
-    sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /www/freepbx/admin/modules/cdr/install.php
-    sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /www/freepbx/admin/modules/cdr/install.php
+    sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' $WEBROOT/admin/modules/cdr/install.php
+    sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' $WEBROOT/admin/modules/cdr/install.php
     echo '** [freepbx] Module Install: cdr'
     fwconsole ma install cdr
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -1,11 +1,16 @@
 #!/usr/bin/with-contenv bash
 
+silent() {
+  if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ];  then
+    "$@"
+  else
+    "$@" > /dev/null 2>&1
+  fi
+}
+
 ### Set Debug Mode
 if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ]; then
     set -x
-    DEBUG=''
-else
-    DEBUG='>/dev/null 2>&1' 
 fi
 
  ## Embedded DB Variance
@@ -138,19 +143,19 @@ option = 3
 EOF
   fi
 
-    sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 $DEBUG
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 9F9169F4B33B4659 $DEBUG
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 3DDB2122FE6D84F7 $DEBUG
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 86CE877469D2EAD9 $DEBUG
+    silent sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80
+    silent sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 9F9169F4B33B4659
+    silent sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 3DDB2122FE6D84F7
+    silent sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 86CE877469D2EAD9
 
     cd /usr/src
     mkdir -p /usr/src/freepbx
-    curl -ssL http://mirror.freepbx.org/modules/packages/freepbx/freepbx-15.0-latest.tgz | tar xfz - --strip 1 -C /usr/src/freepbx $DEBUG
+    silent curl -ssL http://mirror.freepbx.org/modules/packages/freepbx/freepbx-15.0-latest.tgz | tar xfz - --strip 1 -C /usr/src/freepbx
     cd /usr/src/freepbx
     cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
     touch /etc/asterisk/{modules,cdr}.conf
     echo "** [freepbx] Starting Asterisk for the first time.."
-    ./start_asterisk start $DEBUG
+    silent ./start_asterisk start
 
   if [ ! -f "/var/run/asterisk/asterisk.pid" ]; then
     echo "** [freepbx] Can't seem to start Asterisk.. Exitting"
@@ -199,8 +204,8 @@ EOF
 
   echo '** [freepbx] Enabling Default Modules'
   echo '** [freepbx] Module Install: framework, core'
-  fwconsole ma downloadinstall framework core#DEBUG
-  fwconsole ma download cdr $DEBUG
+  silent fwconsole ma downloadinstall framework core 
+  silent fwconsole ma download cdr
 
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then   
     # CDR Hack
@@ -209,28 +214,28 @@ EOF
     cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
     sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /www/freepbx/admin/modules/cdr/install.php
     sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /www/freepbx/admin/modules/cdr/install.php
-    echo '** [freepbx] MModule Install: cdr '
-    fwconsole ma install cdr $DEBUG
+    echo '** [freepbx] Module Install: cdr '
+    silent fwconsole ma install cdr
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
   else
-    echo '** [freepbx] MModule Install: cdr'
-    fwconsole ma install cdr $DEBUG
+    echo '** [freepbx] Module Install: cdr'
+    silent fwconsole ma install cdr
   fi
 
-    echo '** [freepbx] MModule Install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, msuic, sipsettings, voicemail '
-    fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music $DEBUG
-    echo '** [freepbx] MModule Install: certman, userman, pm2'
-    fwconsole ma downloadinstall certman userman pm2 $DEBUG
-    fwconsole chown $DEBUG
-    fwconsole reload $DEBUG
+    echo '** [freepbx] Module Install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, msuic, sipsettings, voicemail '
+    silent fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
+    echo '** [freepbx] Module Install: certman, userman, pm2'
+    silent fwconsole ma downloadinstall certman userman pm2
+    silent fwconsole chown
+    silent fwconsole reload
     chown -R asterisk. /home/asterisk/.npm
     echo '** [freepbx] MModule Install: ucp '
-    fwconsole ma downloadinstall ucp $DEBUG
-    fwconsole chown  $DEBUG
-    fwconsole reload $DEBUG
-    fwconsole restart $DEBUG
+    silent fwconsole ma downloadinstall ucp
+    silent fwconsole chown 
+    silent fwconsole reload
+    silent fwconsole restart
     echo "** [freepbx] Finished Installation of FreePBX Modules - Proceeding with next phase of install"
-    fwconsole stop $DEBUG
+    silent fwconsole stop
     
     cd / 
     rm -rf /usr/src/freepbx
@@ -239,8 +244,8 @@ EOF
       ### FOP2 Installation
       mkdir -p /data/usr/local/fop2
       curl -ssL http://download.fop2.com/install_fop2.sh | bash
-      service apache2 stop $DEBUG
-      service fop2 stop $DEBUG
+      silent service apache2 stop
+      silent service fop2 stop
       chown -R asterisk. /usr/local/fop2/
   fi
 
@@ -353,9 +358,9 @@ if [ ! -f "/usr/sbin/fwconsole" ]; then
   exit 1
 fi
 
-fwconsole chown $DEBUG
-fwconsole start $DEBUG
-fwconsole reload $DEBUG
+silent fwconsole chown
+silent fwconsole start
+silent fwconsole reload
 chown -R asterisk /etc/asterisk/*
 chown -R asterisk:asterisk /etc/amportal.conf
 
@@ -374,13 +379,13 @@ if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
       echo "** [freepbx] Installing Operator Panel"
 
         ### FOP2 Installation
-        fwconsole start $DEBUG
+        silent fwconsole start
         mkdir -p /data/usr/local/fop2
-        curl -ssL http://download.fop2.com/install_fop2.sh | bash $DEBUG
+        silent curl -ssL http://download.fop2.com/install_fop2.sh | bash
         chown -R asterisk. /usr/local/fop2/
-        service apache2 stop $DEBUG
-        service fop2 stop $DEBUG
-        fwconsole stop $DEBUG
+        silent service apache2 stop
+        silent service fop2 stop
+        silent fwconsole stop
     fi
 fi
 
@@ -461,14 +466,14 @@ emailAddress=selfsigned@example.com
 nsCertType = server   
 EOF
 
-    openssl req -new -x509 -nodes -days 365 -config /tmp/openssl.cnf -out /certs/cert.pem -keyout /certs/key.pem $DEBUG
+    silent openssl req -new -x509 -nodes -days 365 -config /tmp/openssl.cnf -out /certs/cert.pem -keyout /certs/key.pem
     chmod 0600 /certs/key.pem
     rm -rf /tmp/openssl.cnf
     TLS_CERT="cert.pem"
     TLS_KEY="key.pem"
     fi  
 
-    a2enmod ssl $DEBUG
+    silent a2enmod ssl
     cat >> /etc/apache2/sites-enabled/000-default.conf << EOF 
 Listen $HTTPS_PORT
 <VirtualHost *:$HTTPS_PORT>
@@ -517,7 +522,7 @@ Listen $HTTP_PORT
 </IfModule>
 EOF
 
-a2enmod remoteip $DEBUG
+silent a2enmod remoteip
 
 cat >> /etc/apache2/conf-available/remoteip.conf << EOF 
 RemoteIPHeader X-Real-IP
@@ -526,8 +531,8 @@ RemoteIPTrustedProxy 172.16.0.0/12
 RemoteIPTrustedProxy 192.168.0.0/16
 EOF
 
-a2enconf allowoverride $DEBUG
-a2enconf remoteip.conf $DEBUG
+silent a2enconf allowoverride
+silent a2enconf remoteip.conf
 
 sed -i 's/\(APACHE_RUN_USER=\)\(.*\)/\1asterisk/g' /etc/apache2/envvars
 sed -i 's/\(APACHE_RUN_GROUP=\)\(.*\)/\1asterisk/g' /etc/apache2/envvars
@@ -538,7 +543,7 @@ chown -R asterisk. /usr/local/fop2
 
 ### Disable Indexes if outside of regular webroot
 if [ "$WEBROOT" != "/var/www/html" ]; then
-  a2dismod autoindex -f $DEBUG
+  silent a2dismod autoindex -f
 fi
 
 ### SMTP Config
@@ -559,7 +564,7 @@ fi
     /usr/local/fop2/fop2_server -d --logdir /var/log/fop
  fi 
 
-service apache2 restart $DEBUG
+silent service apache2 restart
 
 echo '** [freepbx] Web Server Started - Container Initialization Complete'
 

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -3,6 +3,9 @@
 ### Set Debug Mode
 if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ]; then
     set -x
+    DEBUG=''
+else
+    DEBUG='>/dev/null 2>&1' 
 fi
 
  ## Embedded DB Variance
@@ -62,6 +65,23 @@ if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
     done
 fi
 
+### Container Version Sanity Check
+if [ -f /data/etc/asterisk/.asterisk_version ]; then
+  ASTERISK_VERSION_TMP=`cat /data/etc/asterisk/.asterisk_version`
+  ASTERISK_VERSION_TMP=${ASTERISK_VERSION_TMP:0:2}
+
+  if [[ ${ASTERISK_VERSION_TMP//./} -lt "16" ]]; then
+    echo "**"
+    echo "** [freepbx] ERROR - This container has been detected to have FreePBX 14 installed"
+    echo "** [freepbx] ERROR - You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 16"
+    echo "** [freepbx] ERROR - To continue using this image switch to using tiredofit/freepbx:14-latest"
+    echo "** [freepbx] ERROR - See https://github.com/tiredofit/docker-freepbx/issues/51 for more details"
+    echo "** [freepbx] ERROR - This container will now cease to function"
+    echo "**"
+    exit 1
+  fi
+fi
+
 if [ ! -f /data/.installed ]; then
   echo '** [freepbx] Creating Default Configuration Files'
   cp -R /assets/config/* /data/
@@ -105,17 +125,19 @@ Port = $DB_PORT
 option = 3
 
 EOF
-fi
+  fi
 
-    sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 >/dev/null 2>&1
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 9F9169F4B33B4659 >/dev/null 2>&1
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 3DDB2122FE6D84F7 >/dev/null 2>&1
-    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 86CE877469D2EAD9 >/dev/null 2>&1
+    sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 $DEBUG
+    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 9F9169F4B33B4659 $DEBUG
+    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 3DDB2122FE6D84F7 $DEBUG
+    sudo -u asterisk gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 86CE877469D2EAD9 $DEBUG
 
     cd /usr/src
-    git clone --depth=1 -b release/14.0 --single-branch https://github.com/FreePBX/framework.git freepbx >/dev/null 2>&1
+    mkdir -p /usr/src/freepbx
+    curl -ssL http://mirror.freepbx.org/modules/packages/freepbx/freepbx-15.0-latest.tgz | tar xfz - --strip 1 -C /usr/src/freepbx $DEBUG
     cd /usr/src/freepbx
     cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
+    touch /etc/asterisk/{modules,cdr}.conf
     ./start_asterisk start 
 
   if [ ! -f "/var/run/asterisk/asterisk.pid" ]; then
@@ -198,8 +220,8 @@ EOF
       ### FOP2 Installation
       mkdir -p /data/usr/local/fop2
       curl -ssL http://download.fop2.com/install_fop2.sh | bash
-      service apache2 stop > /dev/null
-      service fop2 stop > /dev/null
+      service apache2 stop $DEBUG
+      service fop2 stop $DEBUG
       chown -R asterisk. /usr/local/fop2/
   fi
 
@@ -308,13 +330,13 @@ fi
 echo '** [freepbx] Starting Asterisk'
 
 if [ ! -f "/usr/sbin/fwconsole" ]; then
-  echo "** [freepbx] Can't seem to locate /usr/sbin/fwconsole.. Exitting"
+  echo "** [freepbx] Can't seem to locate /usr/sbin/fwconsole.. Exitting. This is likely because the initial installation of FreePBX fails, and usually an upstream error."
   exit 1
 fi
 
-fwconsole chown > /dev/null 2>&1
-fwconsole start > /dev/null 2>&1
-fwconsole reload > /dev/null 2>&1
+fwconsole chown $DEBUG
+fwconsole start $DEBUG
+fwconsole reload $DEBUG
 chown -R asterisk /etc/asterisk/*
 chown -R asterisk:asterisk /etc/amportal.conf
 
@@ -333,10 +355,12 @@ if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
       echo "** [freepbx] Installing Operator Panel"
 
         ### FOP2 Installation
+        fwconsole start $DEBUG
         mkdir -p /data/usr/local/fop2
-        curl -ssL http://download.fop2.com/install_fop2.sh | bash
-        service apache2 stop > /dev/null
-        service fop2 stop > /dev/null
+        curl -ssL http://download.fop2.com/install_fop2.sh | bash $DEBUG
+        service apache2 stop $DEBUG
+        service fop2 stop $DEBUG
+        fwconsole stop $DEBUG
         chown -R asterisk. /usr/local/fop2/
     fi
 fi
@@ -418,14 +442,14 @@ emailAddress=selfsigned@example.com
 nsCertType = server   
 EOF
 
-    openssl req -new -x509 -nodes -days 365 -config /tmp/openssl.cnf -out /certs/cert.pem -keyout /certs/key.pem
+    openssl req -new -x509 -nodes -days 365 -config /tmp/openssl.cnf -out /certs/cert.pem -keyout /certs/key.pem $DEBUG
     chmod 0600 /certs/key.pem
     rm -rf /tmp/openssl.cnf
     TLS_CERT="cert.pem"
     TLS_KEY="key.pem"
     fi  
 
-    a2enmod ssl >/dev/null
+    a2enmod ssl $DEBUG
     cat >> /etc/apache2/sites-enabled/000-default.conf << EOF 
 Listen $HTTPS_PORT
 <VirtualHost *:$HTTPS_PORT>
@@ -474,7 +498,7 @@ Listen $HTTP_PORT
 </IfModule>
 EOF
 
-a2enmod remoteip >/dev/null 
+a2enmod remoteip $DEBUG
 
 cat >> /etc/apache2/conf-available/remoteip.conf << EOF 
 RemoteIPHeader X-Real-IP
@@ -483,8 +507,8 @@ RemoteIPTrustedProxy 172.16.0.0/12
 RemoteIPTrustedProxy 192.168.0.0/16
 EOF
 
-a2enconf allowoverride >/dev/null
-a2enconf remoteip.conf >/dev/null
+a2enconf allowoverride $DEBUG
+a2enconf remoteip.conf $DEBUG
 
 sed -i 's/\(APACHE_RUN_USER=\)\(.*\)/\1asterisk/g' /etc/apache2/envvars
 sed -i 's/\(APACHE_RUN_GROUP=\)\(.*\)/\1asterisk/g' /etc/apache2/envvars
@@ -495,7 +519,7 @@ chown -R asterisk. /usr/local/fop2
 
 ### Disable Indexes if outside of regular webroot
 if [ "$WEBROOT" != "/var/www/html" ]; then
-  a2dismod autoindex -f
+  a2dismod autoindex -f $DEBUG
 fi
 
 ### SMTP Config
@@ -516,8 +540,7 @@ fi
     /usr/local/fop2/fop2_server -d --logdir /var/log/fop
  fi 
 
-echo $ASTERISK_VERSION > /etc/asterisk/.asterisk-version
-service apache2 restart >/dev/null
+service apache2 restart $DEBUG
 
 echo '** [freepbx] Web Server Started - Container Initialization Complete'
 

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -106,6 +106,7 @@ else
   fi
 fi
 
+### Startup
 if [ ! -f /data/.installed ]; then
   echo '** [freepbx] Creating Default Configuration Files'
   cp -R /assets/config/* /data/
@@ -446,6 +447,9 @@ fi
 if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then 
   echo '    Alias "'$FOP_DIRECTORY'" "/var/www/html/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
 fi
+
+### Update CDR Hack Script
+sed -i -e "s#<WEBROOT>#$WEBROOT#g" /usr/sbin/upgrade-cdr
 
 cat >> /etc/apache2/sites-enabled/000-default.conf << EOF 
 

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -80,6 +80,17 @@ if [ -f /data/etc/asterisk/.asterisk_version ]; then
     echo "**"
     exit 1
   fi
+else
+  if [ -f /data/.installed ]; then
+    echo "**"
+    echo "** [freepbx] ERROR - This container has been detected to have FreePBX 14 installed"
+    echo "** [freepbx] ERROR - You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 16"
+    echo "** [freepbx] ERROR - To continue using this image switch to using tiredofit/freepbx:14-latest"
+    echo "** [freepbx] ERROR - See https://github.com/tiredofit/docker-freepbx/issues/51 for more details"
+    echo "** [freepbx] ERROR - This container will now cease to function"
+    echo "**"
+    exit 1
+  fi
 fi
 
 if [ ! -f /data/.installed ]; then
@@ -187,8 +198,9 @@ EOF
   fi
 
   echo '** [freepbx] Enabling Default Modules'
-  fwconsole ma downloadinstall framework core
-  fwconsole ma download cdr
+  echo '** [freepbx] Module Install: framework, core'
+  fwconsole ma downloadinstall framework core#DEBUG
+  fwconsole ma download cdr $DEBUG
 
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then   
     # CDR Hack
@@ -197,18 +209,23 @@ EOF
     cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
     sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /www/freepbx/admin/modules/cdr/install.php
     sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /www/freepbx/admin/modules/cdr/install.php
-    fwconsole ma install cdr
+    echo '** [freepbx] MModule Install: cdr '
+    fwconsole ma install cdr $DEBUG
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
   else
-    fwconsole ma install cdr
+    echo '** [freepbx] MModule Install: cdr'
+    fwconsole ma install cdr $DEBUG
   fi
 
-    fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
-    fwconsole ma downloadinstall certman userman pm2
+    echo '** [freepbx] MModule Install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, msuic, sipsettings, voicemail '
+    fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music $DEBUG
+    echo '** [freepbx] MModule Install: certman, userman, pm2'
+    fwconsole ma downloadinstall certman userman pm2 $DEBUG
     fwconsole chown $DEBUG
     fwconsole reload $DEBUG
     chown -R asterisk. /home/asterisk/.npm
-    fwconsole ma downloadinstall ucp
+    echo '** [freepbx] MModule Install: ucp '
+    fwconsole ma downloadinstall ucp $DEBUG
     fwconsole chown  $DEBUG
     fwconsole reload $DEBUG
     fwconsole restart $DEBUG

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -212,7 +212,7 @@ EOF
 
   echo '** [freepbx] Enabling Default Modules'
   echo '** [freepbx] Module Install: framework, core'
-  silent fwconsole ma downloadinstall framework core 
+  fwconsole ma downloadinstall framework core 
   fwconsole ma download cdr
   
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then   
@@ -223,22 +223,22 @@ EOF
     sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /www/freepbx/admin/modules/cdr/install.php
     sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /www/freepbx/admin/modules/cdr/install.php
     echo '** [freepbx] Module Install: cdr'
-    silent fwconsole ma install cdr
+    fwconsole ma install cdr
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
   else
     echo '** [freepbx] Module Install: cdr'
-    silent fwconsole ma install cdr
+    fwconsole ma install cdr
   fi
 
     echo '** [freepbx] Module Install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, msuic, sipsettings, voicemail '
-    silent fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
+    fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
     echo '** [freepbx] Module Install: certman, userman, pm2'
-    silent fwconsole ma downloadinstall certman userman pm2
+    fwconsole ma downloadinstall certman userman pm2
     silent fwconsole chown
     silent fwconsole reload
     chown -R asterisk. /home/asterisk/.npm
     echo '** [freepbx] MModule Install: ucp '
-    silent fwconsole ma downloadinstall ucp
+    fwconsole ma downloadinstall ucp
     silent fwconsole chown 
     silent fwconsole reload
     silent fwconsole restart
@@ -250,10 +250,17 @@ EOF
 
   if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then     
       ### FOP2 Installation
+      silent fwconsole start
       mkdir -p /data/usr/local/fop2
-      silent curl -ssL http://download.fop2.com/install_fop2.sh | bash
+      cd /usr/src
+      silent wget http://download.fop2.com/install_fop2.sh
+      chmod +x install_fop2.sh 
+      silent ./install_fop2.sh
+      chown -R asterisk. /usr/local/fop2/
+      rm -rf /usr/src/*
       silent service apache2 stop
       silent service fop2 stop
+      silent fwconsole stop
       chown -R asterisk. /usr/local/fop2/
   fi
 
@@ -389,8 +396,12 @@ if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
         ### FOP2 Installation
         silent fwconsole start
         mkdir -p /data/usr/local/fop2
-        silent curl -ssL http://download.fop2.com/install_fop2.sh | bash
+        cd /usr/src
+        silent wget http://download.fop2.com/install_fop2.sh
+        chmod +x install_fop2.sh 
+        silent ./install_fop2.sh
         chown -R asterisk. /usr/local/fop2/
+        rm -rf /usr/src/*
         silent service apache2 stop
         silent service fop2 stop
         silent fwconsole stop

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -25,21 +25,29 @@ if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
     if [ ! -n "$DB_HOST" ]; then
         echo '** [freepbx] ERROR: No Database Host Entered! '
         exit 1
+    else 
+        DB_EMBEDDED=FALSE
     fi
 
     if [ ! -n "$DB_NAME" ]; then
         echo '** [freepbx] ERROR: No Database Pass Entered! '
         exit 1
+    else 
+        DB_EMBEDDED=FALSE
     fi
 
     if [ ! -n "$DB_USER" ]; then
         echo '** [freepbx] ERROR: No Database User Entered! '
         exit 1
+    else 
+        DB_EMBEDDED=FALSE
     fi
 
     if [ ! -n "$DB_PASS" ]; then
         echo '** [freepbx] ERROR: No Database Pass Entered! '
         exit 1
+    else 
+        DB_EMBEDDED=FALSE
     fi
 fi
 
@@ -214,7 +222,7 @@ EOF
     cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
     sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /www/freepbx/admin/modules/cdr/install.php
     sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /www/freepbx/admin/modules/cdr/install.php
-    echo '** [freepbx] Module Install: cdr '
+    echo '** [freepbx] Module Install: cdr'
     silent fwconsole ma install cdr
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
   else

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -138,7 +138,8 @@ EOF
     cd /usr/src/freepbx
     cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
     touch /etc/asterisk/{modules,cdr}.conf
-    ./start_asterisk start 
+    echo "** [freepbx] Starting Asterisk for the first time.."
+    ./start_asterisk start $DEBUG
 
   if [ ! -f "/var/run/asterisk/asterisk.pid" ]; then
     echo "** [freepbx] Can't seem to start Asterisk.. Exitting"
@@ -204,14 +205,15 @@ EOF
 
     fwconsole ma downloadinstall voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
     fwconsole ma downloadinstall certman userman pm2
-    fwconsole chown 
-    fwconsole reload 
+    fwconsole chown $DEBUG
+    fwconsole reload $DEBUG
     chown -R asterisk. /home/asterisk/.npm
     fwconsole ma downloadinstall ucp
-    fwconsole chown 
-    fwconsole reload 
-    fwconsole restart
-    fwconsole stop
+    fwconsole chown  $DEBUG
+    fwconsole reload $DEBUG
+    fwconsole restart $DEBUG
+    echo "** [freepbx] Finished Installation of FreePBX Modules - Proceeding with next phase of install"
+    fwconsole stop $DEBUG
     
     cd / 
     rm -rf /usr/src/freepbx
@@ -358,10 +360,10 @@ if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
         fwconsole start $DEBUG
         mkdir -p /data/usr/local/fop2
         curl -ssL http://download.fop2.com/install_fop2.sh | bash $DEBUG
+        chown -R asterisk. /usr/local/fop2/
         service apache2 stop $DEBUG
         service fop2 stop $DEBUG
         fwconsole stop $DEBUG
-        chown -R asterisk. /usr/local/fop2/
     fi
 fi
 

--- a/install/usr/sbin/upgrade-cdr
+++ b/install/usr/sbin/upgrade-cdr
@@ -3,11 +3,11 @@
 if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then  
 	## This is a dirty hack to allow for updating the CDR Module to use a seperate DB Host and the same DB as FreePBX.
 		echo '** [freepbx] Performing Manual Upgrade of CDR Module'
-		cp -R /var/www/html/admin/modules/cdr/install.php /var/www/html/admin/modules/cdr/.install.php
-		sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' /var/www/html/admin/modules/cdr/install.php
-		sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' /var/www/html/admin/modules/cdr/install.php
+		cp -R <WEBROOT>/admin/modules/cdr/install.php <WEBROOT>/admin/modules/cdr/.install.php
+		sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' <WEBROOT>/admin/modules/cdr/install.php
+		sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' <WEBROOT>/admin/modules/cdr/install.php
 		fwconsole ma upgrade cdr
-		cp -R /var/www/html/admin/modules/cdr/.install.php /var/www/html/admin/modules/cdr/install.php
+		cp -R <WEBROOT>/admin/modules/cdr/.install.php <WEBROOT>/admin/modules/cdr/install.php
 		fwconsole chown 
     	fwconsole reload
     	chown -R asterisk /etc/asterisk


### PR DESCRIPTION
This is a breaking changes image that does not support upgrading from a previously installed 2.x/Freepbx 14 Release. To stay on that base use the `14` branch and adjust your docker image to use `tiredofit/freepbx:14-latest`