### PR TITLE
Set ports to udp

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -9,8 +9,8 @@ services:
      #- 80:80
      #### If you want SSL Support and not using a reverse proxy
      #- 443:443
-      - 5060:5060
-      - 5160:5160
+      - 5060:5060/udp
+      - 5160:5160/udp
       - 18000-18100:18000-18100/udp
      #### Flash Operator Panel
       - 4445:4445


### PR DESCRIPTION
Set ports 5060 and 5160 to udp according to the freepbx documentation.
https://wiki.freepbx.org/display/PPS/Ports+used+on+your+PBX