### PR TITLE
fix apache error when using ENABLE_SSL

### DIFF
--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -470,7 +470,6 @@ EOF
 
     silent a2enmod ssl
     cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
-Listen $HTTPS_PORT
 <VirtualHost *:$HTTPS_PORT>
     SSLEngine on
     SSLCertificateFile "/certs/$TLS_CERT"


### PR DESCRIPTION
Apache throws and error because ports.conf contains the listen directive for it. 000-default.conf also adds a Listen 443 which is removed to allow the ports.conf file to enabled it if the module is available.

```Listen 80

<IfModule ssl_module>
  Listen 443
</IfModule>

<IfModule mod_gnutls.c>
  Listen 443
</IfModule>