### PR TITLE
Asterisk 17.4.0 support and other patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,62 +3,99 @@ LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Set defaults
 ENV ASTERISK_VERSION=17.4.0 \
-    FREEPBX_VERSION=15.0.16.55 \
-    MARIAODBC_VERSION=3.1.7 \
     BCG729_VERSION=1.0.4 \
+    DONGLE_VERSION=20200610 \
+    G72X_CPUHOST=penryn \
+    G72X_VERSION=0.1 \
+    FREEPBX_VERSION=15.0.16.55 \
+    MONGODB_VERSION=4.2 \
+    PHP_VERSION=5.6 \
     SPANDSP_VERSION=20180108 \
+    RTP_START=18000 \
+    RTP_FINISH=20000 \
     DB_EMBEDDED=TRUE \
+    ENABLE_CRON=TRUE \
+    ENABLE_SMTP=TRUE \
     UCP_FIRST=TRUE
 
 ### Pin libxml2 packages to Debian repositories
 RUN echo "Package: libxml2*" > /etc/apt/preferences.d/libxml2 && \
     echo "Pin: release o=Debian,n=buster" >> /etc/apt/preferences.d/libxml2 && \
-    echo "Pin-Priority: 501" >> /etc/apt/preferences.d/libxml2
-
+    echo "Pin-Priority: 501" >> /etc/apt/preferences.d/libxml2 && \
+    APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=TRUE && \
+    \
 ### Install dependencies
-RUN set -x && \
+    set -x && \
     curl https://packages.sury.org/php/apt.gpg | apt-key add - && \
     echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/deb.sury.org.list && \
-    curl https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add - && \
-    echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" > /etc/apt/sources.list.d/mongodb-org.list && \
+    curl https://www.mongodb.org/static/pgp/server-${MONGODB_VERSION}.asc | apt-key add - && \
+    echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/${MONGODB_VERSION} main" > /etc/apt/sources.list.d/mongodb-org.list && \
+    echo "deb http://ftp.us.debian.org/debian/ buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    echo "deb-src http://ftp.us.debian.org/debian/ buster-backports main" >> /etc/apt/sources.list.d/backports.list && \
     apt-get update  && \
     apt-get -o Dpkg::Options::="--force-confold" upgrade -y && \
     \
 ### Install development dependencies
-    \
     ASTERISK_BUILD_DEPS='\
                         autoconf \
                         automake \
                         bison \
+                        binutils-dev \
                         build-essential \
                         doxygen \
                         flex \
+                        graphviz \
                         libasound2-dev \
+                        libbluetooth-dev \
+                        libc-client2007e-dev \
+                        libcfg-dev \
+                        libcodec2-dev \
+                        libcorosync-common-dev \
+                        libcpg-dev \
                         libcurl4-openssl-dev \
                         libedit-dev \
+                        libfftw3-dev \
+                        libgmime-2.6-dev \
+                        libgsm1-dev \
                         libical-dev \
                         libiksemel-dev \
                         libjansson-dev \
+                        libldap2-dev \
+                        liblua5.2-dev \
+                        libmariadb-dev \
                         libmariadbclient-dev \
+                        libmp3lame-dev \
                         libncurses5-dev \
                         libneon27-dev \
                         libnewt-dev \
                         libogg-dev \
+                        libopus-dev \
+                        libosptk-dev \
+                        libpopt-dev \
+                        libradcli-dev \
                         libresample1-dev \
-                        libspandsp-dev \
+                        libsndfile1-dev \
+                        libsnmp-dev \
+                        libspeex-dev \
+                        libspeexdsp-dev \
                         libsqlite3-dev \
                         libsrtp2-dev \
                         libssl-dev \
                         libtiff-dev \
                         libtool-bin \
+                        libunbound-dev \
+                        liburiparser-dev \
                         libvorbis-dev \
+                        libvpb-dev \
                         libxml2-dev \
+                        libxslt1-dev \
                         linux-headers-amd64 \
+                        portaudio19-dev \
                         python-dev \
                         subversion \
                         unixodbc-dev \
                         uuid-dev \
-                        ' && \
+                        zlib1g-dev' && \
     \
 ### Install runtime dependencies
     apt-get install --no-install-recommends -y \
@@ -66,33 +103,52 @@ RUN set -x && \
                     apache2 \
                     composer \
                     fail2ban \
-                    flite \
                     ffmpeg \
+                    flite \
+                    freetds-dev \
                     git \
                     g++ \
                     iptables \
                     lame \
+                    libavahi-client3 \
+                    libbluetooth3 \
+                    libc-client2007e \
+                    libcfg7 \
+                    libcpg4 \
+                    libgmime-2.6 \
+                    libical3 \
                     libiodbc2 \
+                    libiksemel3 \
                     libicu63 \
                     libicu-dev \
+                    libneon27 \
+                    libosptk4 \
+                    libresample1 \
+                    libsnmp30 \
+                    libspeexdsp1 \
                     libsrtp2-1 \
+                    libunbound8 \
+                    liburiparser1 \
+                    libvpb1 \
                     locales \
                     locales-all \
+                    make \
                     mariadb-client \
                     mariadb-server \
                     mongodb-org \
                     mpg123 \
-                    php5.6 \
-                    php5.6-cli \
-                    php5.6-curl \
-                    php5.6-gd \
-                    php5.6-ldap \
-                    php5.6-mbstring \
-                    php5.6-mysql \
-                    php5.6-sqlite \
-                    php5.6-xml \
-                    php5.6-zip \
-                    php5.6-intl \
+                    odbc-mariadb \
+                    php${PHP_VERSION} \
+                    php${PHP_VERSION}-curl \
+                    php${PHP_VERSION}-cli \
+                    php${PHP_VERSION}-mysql \
+                    php${PHP_VERSION}-gd \
+                    php${PHP_VERSION}-mbstring \
+                    php${PHP_VERSION}-intl \
+                    php${PHP_VERSION}-bcmath \
+                    php${PHP_VERSION}-ldap \
+                    php${PHP_VERSION}-xml \
+                    php${PHP_VERSION}-zip \
                     php-pear \
                     pkg-config \
                     sipsak \
@@ -105,14 +161,7 @@ RUN set -x && \
                     uuid \
                     wget \
                     whois \
-                    xmlstarlet \
-                    && \
-    \
-### Install MariaDB ODBC connector
-    cd /usr/src && \
-    mkdir -p mariadb-connector && \
-    curl -sSL  https://downloads.mariadb.com/Connectors/odbc/connector-odbc-${MARIAODBC_VERSION}/mariadb-connector-odbc-${MARIAODBC_VERSION}-ga-debian-x86_64.tar.gz | tar xvfz - -C /usr/src/mariadb-connector && \
-    cp mariadb-connector/lib/libmaodbc.so /usr/lib/x86_64-linux-gnu/odbc/ && \
+                    xmlstarlet && \
     \
 ### Add users
     addgroup --gid 2600 asterisk && \
@@ -122,7 +171,7 @@ RUN set -x && \
     mkdir -p /usr/src/spandsp && \
     curl -kL http://sources.buildroot.net/spandsp/spandsp-${SPANDSP_VERSION}.tar.gz | tar xvfz - --strip 1 -C /usr/src/spandsp && \
     cd /usr/src/spandsp && \
-    ./configure && \
+    ./configure --prefix=/usr && \
     make && \
     make install && \
     \
@@ -133,30 +182,62 @@ RUN set -x && \
     cd /usr/src/asterisk/ && \
     make distclean && \
     contrib/scripts/get_mp3_source.sh && \
-    ./configure --with-resample --with-pjproject-bundled --with-jansson-bundled --with-ssl=ssl --with-srtp && \
+    ./configure \
+        --with-jansson-bundled \
+        --with-pjproject-bundled \
+        --with-bluetooth \
+        --with-codec2 \
+        --with-corosync \
+        --with-crypto \
+        --with-ffmpeg \
+        --with-freetds \
+        --with-gmime \
+        --with-iconv \
+        --with-iksemel \
+        --with-inotify \
+        --with-ldap \
+        --with-libxml2 \
+        --with-libxslt \
+        --with-lua \
+        --with-ogg \
+        --with-openssl \
+        --with-opus \
+        --with-resample \
+        --with-spandsp \
+        --with-speex \
+        --with-sqlite3 \
+        --with-srtp \
+        --with-unixodbc \
+        --with-uriparser \
+        --with-vorbis \
+        --with-vpb \
+        --with-zlib && \
+    \
     make menuselect/menuselect menuselect-tree menuselect.makeopts && \
     menuselect/menuselect --disable BUILD_NATIVE \
-                          --enable app_confbridge \
-                          --enable app_fax \
-                          --enable app_macro \
-                          --enable codec_opus \
-                          --enable codec_silk \
-                          --enable format_mp3 \
+                          --enable-category MENUSELECT_ADDONS \
+                          --enable-category MENUSELECT_APPS \
+                          --enable-category MENUSELECT_CHANNELS \
+                          --enable-category MENUSELECT_CODECS \
+                          --enable-category MENUSELECT_FORMATS \
+                          --enable-category MENUSELECT_FUNCS \
+                          --enable-category MENUSELECT_RES \
                           --enable BETTER_BACKTRACES \
                           --disable MOH-OPSOUND-WAV \
                           --enable MOH-OPSOUND-GSM \
+                          --disable codec_g723 \
+                          --disable codec_g729a && \
     make && \
     make install && \
     make install-headers && \
     make config && \
-    ldconfig && \
     \
 #### Add G729 codecs
     git clone https://github.com/BelledonneCommunications/bcg729 /usr/src/bcg729 && \
     cd /usr/src/bcg729 && \
     git checkout tags/$BCG729_VERSION && \
     ./autogen.sh && \
-    ./configure --libdir=/lib && \
+    ./configure --prefix=/usr --libdir=/lib && \
     make && \
     make install && \
     \
@@ -164,23 +245,33 @@ RUN set -x && \
     curl https://bitbucket.org/arkadi/asterisk-g72x/get/master.tar.gz | tar xvfz - --strip 1 -C /usr/src/asterisk-g72x && \
     cd /usr/src/asterisk-g72x && \
     ./autogen.sh && \
-    ./configure --with-bcg729 --enable-penryn && \
+    ./configure --prefix=/usr --with-bcg729 --enable-$G72X_CPUHOST && \
     make && \
     make install && \
+    \
+#### Add usb dongle modem support
+    git clone https://github.com/rusxakep/asterisk-chan-dongle /usr/src/asterisk-chan-dongle && \
+    cd /usr/src/asterisk-chan-dongle && \
+    git checkout tags/$DONGLE_VERSION && \
+    ./bootstrap && \
+    ./configure --with-astversion=$ASTERISK_VERSION && \
+    make && \
+    make install && \
+    \
+    ldconfig && \
     \
 ### Cleanup
     mkdir -p /var/run/fail2ban && \
     cd / && \
     rm -rf /usr/src/* /tmp/* /etc/cron* && \
-    apt-get purge -y $ASTERISK_BUILD_DEPS libspandsp-dev && \
+    apt-get purge -y $ASTERISK_BUILD_DEPS && \
     apt-get -y autoremove && \
     apt-get clean && \
-    apt-get install -y make && \
     rm -rf /var/lib/apt/lists/* && \
     \
 ### FreePBX hacks
-    sed -i -e "s/memory_limit = 128M/memory_limit = 256M/g" /etc/php/5.6/apache2/php.ini && \
-    sed -i 's/\(^upload_max_filesize = \).*/\120M/' /etc/php/5.6/apache2/php.ini && \
+    sed -i -e "s/memory_limit = 128M/memory_limit = 256M/g" /etc/php/${PHP_VERSION}/apache2/php.ini && \
+    sed -i 's/\(^upload_max_filesize = \).*/\120M/' /etc/php/${PHP_VERSION}/apache2/php.ini && \
     a2disconf other-vhosts-access-log.conf && \
     a2enmod rewrite && \
     a2enmod headers && \
@@ -215,7 +306,7 @@ RUN set -x && \
     ln -s /data/etc/asterisk /etc/asterisk
 
 ### Networking configuration
-EXPOSE 80 443 4445 4569 5060/udp 5160/udp 5061 5161 8001 8003 8008 8009 18000-20000/udp
+EXPOSE 80 443 4445 4569 5060/udp 5160/udp 5061 5161 8001 8003 8008 8009 ${RTP_START}-${RTP_FINISH}/udp
 
 ### Files add
 ADD install /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM tiredofit/nodejs:10-debian-latest
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
-### Set Defaults
-ENV ASTERISK_VERSION=16.9.0 \
-    FREEPBX_VERSION=15.0.16.45 \
-    MARIAODBC_VERSION=2.0.19 \
+### Set defaults
+ENV ASTERISK_VERSION=17.4.0 \
+    FREEPBX_VERSION=15.0.16.55 \
+    MARIAODBC_VERSION=3.1.7 \
     BCG729_VERSION=1.0.4 \
     SPANDSP_VERSION=20180108 \
     DB_EMBEDDED=TRUE \
@@ -15,7 +15,7 @@ RUN echo "Package: libxml2*" > /etc/apt/preferences.d/libxml2 && \
     echo "Pin: release o=Debian,n=buster" >> /etc/apt/preferences.d/libxml2 && \
     echo "Pin-Priority: 501" >> /etc/apt/preferences.d/libxml2
 
-### Install Dependencies
+### Install dependencies
 RUN set -x && \
     curl https://packages.sury.org/php/apt.gpg | apt-key add - && \
     echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/deb.sury.org.list && \
@@ -24,7 +24,7 @@ RUN set -x && \
     apt-get update  && \
     apt-get -o Dpkg::Options::="--force-confold" upgrade -y && \
     \
-### Install Development Dependencies
+### Install development dependencies
     \
     ASTERISK_BUILD_DEPS='\
                         autoconf \
@@ -60,7 +60,7 @@ RUN set -x && \
                         uuid-dev \
                         ' && \
     \
-### Install Runtime Dependencies
+### Install runtime dependencies
     apt-get install --no-install-recommends -y \
                     $ASTERISK_BUILD_DEPS \
                     apache2 \
@@ -108,13 +108,13 @@ RUN set -x && \
                     xmlstarlet \
                     && \
     \
-### Install MariaDB ODBC Connector
+### Install MariaDB ODBC connector
     cd /usr/src && \
     mkdir -p mariadb-connector && \
     curl -sSL  https://downloads.mariadb.com/Connectors/odbc/connector-odbc-${MARIAODBC_VERSION}/mariadb-connector-odbc-${MARIAODBC_VERSION}-ga-debian-x86_64.tar.gz | tar xvfz - -C /usr/src/mariadb-connector && \
     cp mariadb-connector/lib/libmaodbc.so /usr/lib/x86_64-linux-gnu/odbc/ && \
     \
-### Add Users
+### Add users
     addgroup --gid 2600 asterisk && \
     adduser --uid 2600 --gid 2600 --gecos "Asterisk User" --disabled-password asterisk && \
     \
@@ -151,7 +151,7 @@ RUN set -x && \
     make config && \
     ldconfig && \
     \
-#### Add G729 Codecs
+#### Add G729 codecs
     git clone https://github.com/BelledonneCommunications/bcg729 /usr/src/bcg729 && \
     cd /usr/src/bcg729 && \
     git checkout tags/$BCG729_VERSION && \
@@ -168,7 +168,7 @@ RUN set -x && \
     make && \
     make install && \
     \
-### Cleanup 
+### Cleanup
     mkdir -p /var/run/fail2ban && \
     cd / && \
     rm -rf /usr/src/* /tmp/* /etc/cron* && \
@@ -178,7 +178,7 @@ RUN set -x && \
     apt-get install -y make && \
     rm -rf /var/lib/apt/lists/* && \
     \
-### FreePBX Hacks
+### FreePBX hacks
     sed -i -e "s/memory_limit = 128M/memory_limit = 256M/g" /etc/php/5.6/apache2/php.ini && \
     sed -i 's/\(^upload_max_filesize = \).*/\120M/' /etc/php/5.6/apache2/php.ini && \
     a2disconf other-vhosts-access-log.conf && \
@@ -189,10 +189,10 @@ RUN set -x && \
     mkdir -p /var/log/apache2 && \
     mkdir -p /var/log/httpd && \
     \
-### Zabbix Setup
+### Zabbix setup
     echo '%zabbix ALL=(asterisk) NOPASSWD:/usr/sbin/asterisk' >> /etc/sudoers && \
     \
-### Setup for Data Persistence
+### Setup for data persistence
     mkdir -p /assets/config/var/lib/ /assets/config/home/ && \
     mv /home/asterisk /assets/config/home/ && \
     ln -s /data/home/asterisk /home/asterisk && \
@@ -214,8 +214,8 @@ RUN set -x && \
     rm -rf /etc/asterisk && \
     ln -s /data/etc/asterisk /etc/asterisk
 
-### Networking Configuration
+### Networking configuration
 EXPOSE 80 443 4445 4569 5060/udp 5160/udp 5061 5161 8001 8003 8008 8009 18000-20000/udp
 
-### Files Add
+### Files add
 ADD install /

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # hub.docker.com/r/tiredofit/freepbx
 
 [![Build Status](https://img.shields.io/docker/build/tiredofit/freepbx.svg)](https://hub.docker.com/r/tiredofit/freepbx)
@@ -9,20 +8,21 @@
 
 # Introduction
 
-This will build a container for [FreePBX](https://www.freepbx.org) - A Voice over IP Manager for Asterisk. Upon starting this image it will give you a turn-key PBX system for SIP calling. 
+This will build a container for [FreePBX](https://www.freepbx.org) - A Voice over IP manager for Asterisk. 
+Upon starting this image it will give you a turn-key PBX system for SIP calling. 
 
-* Latest release Version 15
-* Compiles and Installs Asterisk 17
-* Choice of running embedded database or Modifies to support external MariaDB Database and only require one DB.
-* Supports Data Persistence
+* Latest release FreePBX 15
+* Latest release Asterisk 17
+* Choice of running embedded database or modifies to support external MariaDB Database and only require one DB.
+* Supports data persistence
 * Fail2Ban installed to block brute force attacks
-* Debian Buster Base w/ Apache2
+* Debian Buster base w/ Apache2
 * NodeJS 10.x
-* Automatically Installs User Control Panel and displays at first page
+* Automatically installs User Control Panel and displays at first page
 * Option to Install [Flash Operator Panel 2](https://www.fop2.com/)
 * Customizable FOP and Admin URLs
 
-This Container uses [tiredofit/debian:buster](https://hub.docker.com/r/tiredofit/debian) as a base.
+This container uses [tiredofit/debian:buster](https://hub.docker.com/r/tiredofit/debian) as a base.
         
 **If you are presently running this image when it utilized FreePBX 14 and 
 Asterisk 14 and can no longer use your image, please see [this post](https://github.com/tiredofit/docker-freepbx/issues/51)**
@@ -53,11 +53,10 @@ Asterisk 14 and can no longer use your image, please see [this post](https://git
 
 This image assumes that you are using a reverse proxy such as 
 [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) and optionally the [Let's Encrypt Proxy 
-Companion @ 
-https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) 
+Companion @ https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) 
 in order to serve your pages. However, it will run just fine on it's own if you map appropriate ports.
 
-You will also need an external MySQL/MariaDB Container, athough it can use an internally provided service (not recommended).
+You will also need an external MySQL/MariaDB container, although it can use an internally provided service (not recommended).
 
 # Installation
 
@@ -69,16 +68,17 @@ docker pull tiredofit/freepbx:(imagetag)
 ```
 The following image tags are available:
 
-* `15` - Asterisk 16, Freepbx 15 - Debian Buster (latest build)
+* `15` - Asterisk 17, Freepbx 15 - Debian Buster (latest build)
 * `14` - Asterisk 14, Freepbx 14 - Debian Stretch (latest build)
-* `latest` - Asterisk 16, Freepbx 15 - Debian Buster (Same as `15`)
+* `latest` - Asterisk 17, Freepbx 15 - Debian Buster (Same as `15`)
 
 You can also visit the image tags section on Docker hub to pull a version that follows the CHANGELOG.
 
 
 # Quick Start
 
-* The quickest way to get started is using [docker-compose](https://docs.docker.com/compose/). See the examples folder for a working [docker-compose.yml](examples/docker-compose.yml) that can be modified for development or production use.
+* The quickest way to get started is using [docker-compose](https://docs.docker.com/compose/). 
+See the example's folder for a working [docker-compose.yml](examples/docker-compose.yml) that can be modified for development or production use.
 
 * Set various [environment variables](#environment-variables) to understand the capabilities of this image.
 * Map [persistent storage](#data-volumes) for access to configuration and data files for backup.
@@ -92,22 +92,26 @@ Login to the web server's admin URL (default /admin) and enter in your admin use
 
 ### Data-Volumes
 
-The container supports data persistence and during Dockerfile Build creates symbolic links for `/var/lib/asterisk`, `/var/spool/asterisk`, `/home/asterisk`, and `/etc/asterisk`. Upon startup configuration files are copied and generated to support portability.
+The container supports data persistence and during Dockerfile build creates symbolic links for 
+`/var/lib/asterisk`, `/var/spool/asterisk`, `/home/asterisk`, and `/etc/asterisk`. 
+Upon startup configuration files are copied and generated to support portability.
 
-The following directories are used for configuration and can be mapped for persistent storage.
+The following directories are used for configure and can be mapped for persistent storage.
 
 | Directory    | Description                                                 |
 |--------------|-------------------------------------------------------------|
-|  `/certs`    | Drop your Certificates here for TLS w/PJSIP / UCP / HTTPd/ FOP |
+|  `/certs`    | Drop your certificates here for TLS w/PJSIP / UCP / HTTPd/ FOP |
 |  `/var/www/html` | FreePBX web files |
 |  `/var/log/` | Apache, Asterisk and FreePBX Log Files |
-|  `/data`      | Data Persistence for Asterisk and Freepbx and FOP
-|  `/assets/custom` | *OPTIONAL* - If you would like to overwrite some files in the container, put them here following the same folder structure for anything underneath the /var/www/html directory |
+|  `/data`      | Data persistence for Asterisk and FreePBX and FOP
+|  `/assets/custom` | *OPTIONAL* - If you would like to overwrite some files in the container, 
+put them here following the same folder structure for anything underneath the /var/www/html directory |
 
 ### Environment Variables
 
 
-Along with the Environment Variables from the [Base image](https://hub.docker.com/r/tiredofit/debian), below is the complete list of available options that can be used to customize your installation.
+Along with the environment variables from the [Base image](https://hub.docker.com/r/tiredofit/debian), 
+below is the complete list of available options that can be used to customize your installation.
 
 | Parameter        | Description                            |
 |------------------|----------------------------------------|
@@ -116,20 +120,20 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `DB_HOST` | Host or container name of MySQL Server e.g. `freepbx-db` |
 | `DB_PORT` | MySQL Port - Default `3306` |
 | `DB_NAME` | MySQL Database name e.g. `asterisk` |
-| `DB_USER` | MySQL Username for above Database e.g. `asterisk` |
-| `DB_PASS` | MySQL Password for above Database e.g. `password`|
-| `ENABLE_FAIL2BAN` | Enable Fail2ban to block the bad guys - Default `TRUE`|
+| `DB_USER` | MySQL Username for above database e.g. `asterisk` |
+| `DB_PASS` | MySQL Password for above database e.g. `password`|
+| `ENABLE_FAIL2BAN` | Enable Fail2ban to block the "bad guys" - Default `TRUE`|
 | `ENABLE_FOP` | Enable Flash Operator Panel - Default `TRUE` |
 | `ENABLE_SSL` | Enable HTTPd to serve SSL requests - Default `FALSE`|
 | `ENABLE_XMPP` | Enable XMPP Module with MongoDB - Default `FALSE` |
 | `FOP_DIRECTORY` | What folder to access FOP - Default `/fop`
-| `HTTP_PORT`  | HTTP Listening Port - Default `80` |
-| `HTTPS_PORT`  | HTTPS Listening Port - Default `443` |
+| `HTTP_PORT`  | HTTP listening port - Default `80` |
+| `HTTPS_PORT`  | HTTPS listening port - Default `443` |
 | `INSTALL_ADDITIONAL_MODULES` | Comma separated list of modules to additionally install on first container startup |
-| `RTP_START` | What port to start RTP Transmissions - Default `18000` |
-| `RTP_FINISH` | What port to start RTP Transmissions - Default `20000` |
+| `RTP_START` | What port to start RTP transmissions - Default `18000` |
+| `RTP_FINISH` | What port to start RTP transmissions - Default `20000` |
 | `UCP_FIRST` | Load UCP as web frontpage `TRUE/FALSE` - Default `TRUE` |
-| `TLS_CERT` | TLS Certificate to drop in /certs for HTTPS if no reverse proxy |
+| `TLS_CERT` | TLS certificate to drop in /certs for HTTPS if no reverse proxy |
 | `TLS_KEY` | TLS Key to drop in /certs for HTTPS if no reverse proxy |
 | `WEBROOT` | If you wish to install to a subfolder use this. Example: `/var/www/html/pbx` Default '/var/www/html'
 
@@ -151,16 +155,21 @@ The following ports are exposed.
 | `8003`    | UCP SSL     |
 | `8008`    | UCP         |
 | `8009`    | UCP SSL     |
-| `18000-20000/udp` | RTP Ports |
+| `18000-20000/udp` | RTP ports |
 
 # Maintenance
 
-* There seems to be a problem with the CDR Module when updating where it refuses to update when using an external DB Server. If that happens, simply enter the container (as shown below) and execute `upgrade-cdr`, which will download the latest CDR module, apply a tweak, install, and reload the system for you.
+* There seems to be a problem with the CDR Module when updating where it refuses to update when using an external DB Server. 
+If that happens, simply enter the container (as shown below) and execute `upgrade-cdr`, which will download the latest CDR module, 
+apply a tweak, install, and reload the system for you.
 
 # Known Bugs
 
-* When installing Parking Lot or Feature Codes you sometimes get `SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'helptext' at row 1`. To resolve login to your SQL server and issue this statement: `alter table featurecodes modify column helptext varchar(500);`
-* If you find yourself needing to update the framework or core modules and experience issues, enter the container and run `upgrade-core` which will truncate the column and auto upgrade the core and framework modules.
+* When installing Parking Lot or Feature Codes you sometimes get `SQLSTATE[22001]: String data, right truncated: 
+1406 Data too long for column 'helptext' at row 1`. To resolve login to your SQL server and issue this statement: 
+`alter table featurecodes modify column helptext varchar(500);`
+* If you find yourself needing to update the framework or core modules and experience issues, enter the container and 
+run `upgrade-core` which will truncate the column and auto upgrade the core and framework modules.
 
 #### Shell Access
 

--- a/install/assets/functions/10-freepbx
+++ b/install/assets/functions/10-freepbx
@@ -8,14 +8,14 @@ ENABLE_XMPP=${ENABLE_XMPP:-"FALSE"}
 FOP_DIRECTORY=${FOP_DIRECTORY:-"/fop"}
 HTTP_PORT=${HTTP_PORT:-80}
 HTTPS_PORT=${HTTPS_PORT:-443}
-RTP_FINISH=${RTP_FINISH:-20000}
 RTP_START=${RTP_START:-18000}
+RTP_FINISH=${RTP_FINISH:-20000}
 UCP_FIRST=${UCP_FIRST:-"TRUE"}
 WEBROOT=${WEBROOT:-"/var/www/html"}
 
 check_process() {
-  while [ true ]; do
-    pid=`pgrep php | wc -l`
+  while true; do
+    pid=$(pgrep php | wc -l)
     if [ "$pid" = "1" ]; then
       sleep 3
     else

--- a/install/etc/cont-finish.d/10-freepbx
+++ b/install/etc/cont-finish.d/10-freepbx
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-## Embedded DB Variance
+## Embedded DB variance
   if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
      DB_EMBEDDED=TRUE
   else

--- a/install/etc/cont-finish.d/10-freepbx
+++ b/install/etc/cont-finish.d/10-freepbx
@@ -1,20 +1,13 @@
 #!/usr/bin/with-contenv bash
 
-## Embedded DB variance
-  if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
-     DB_EMBEDDED=TRUE
-  else
-     DB_EMBEDDED=FALSE      
-  fi
-  
 fwconsole stop
 service apache2 stop
 
-if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
+if var_true "$DB_EMBEDDED" ;  then
 	service mysql stop
 fi
 
-if [[ "$ENABLE_XMPP" = "TRUE" ]] || [[ "$ENABLE_XMPP" = "true" ]];  then
+if var_true "$ENABLE_XMPP" ;  then
 	mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf --shutdown
 fi
 

--- a/install/etc/cont-init.d/03-cron
+++ b/install/etc/cont-init.d/03-cron
@@ -1,18 +1,20 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="cron"
 
-### Set Defaults
+### Set defaults
 ENABLE_CRON=${ENABLE_CRON:-"TRUE"}
 
-### Check to see if Enabled/Disabled
-if [ "$ENABLE_CRON" = "FALSE" ] || [ "$ENABLE_CRON" = "false" ];  then
-        print_notice "Disabling Cron"
-        service_stop `basename $0`
+### Check to see if enabled/disabled
+if var_false $ENABLE_CRON ;  then
+  print_notice "Disabling Cron"
+  service_stop $(basename $0)
 fi
 
-print_debug "Creating Cron Folder"
+print_debug "Creating Cron folder"
 silent mkdir -p /var/spool/cron
 
 liftoff

--- a/install/etc/cont-init.d/05-fail2ban
+++ b/install/etc/cont-init.d/05-fail2ban
@@ -1,9 +1,11 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="fail2ban"
 
-if [[ "$ENABLE_FAIL2BAN" = "TRUE" ]] || [[ "$ENABLE_FAIL2BAN" = "true" ]];  then
+if var_true "$ENABLE_FAIL2BAN" ;  then
 	sed -i -e "s/logtarget = \/var\/log\/fail2ban.log/logtarget = \/var\/log\/fail2ban\/fail2ban.log/g" /etc/fail2ban/fail2ban.conf
 	rm -rf /etc/fail2ban/jail.d/*
 	mkdir -p /var/log/asterisk/

--- a/install/etc/cont-init.d/08-mongodb
+++ b/install/etc/cont-init.d/08-mongodb
@@ -1,14 +1,16 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="mongo"
 
-if [[ "$ENABLE_XMPP" = "TRUE" ]] || [[ "$ENABLE_XMPP" = "true" ]];  then
+if var_true "$ENABLE_XMPP" ;  then
 	print_notice "Enabling MongoDB for XMPP support"
-    mkdir -p /var/log/mongodb
-    touch /var/log/mongodb/mongodb.log
-    mkdir -p /data/var/lib/mongodb
-    service_start /var/run/s6/services/08-mongodb
+	mkdir -p /data/var/lib/mongodb
+  mkdir -p /var/log/mongodb
+  touch /var/log/mongodb/mongod.log
+  service_start 08-mongodb
 else
 	service_stop 08-mongodb	 
 fi

--- a/install/etc/cont-init.d/09-mariadb
+++ b/install/etc/cont-init.d/09-mariadb
@@ -1,25 +1,20 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="mariadb"
 
- ## Embedded DB Variance
-  if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
-     DB_EMBEDDED=TRUE
-  else
-     DB_EMBEDDED=FALSE
-  fi
-
-  if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
+if var_true "$DB_EMBEDDED" ;  then
   silent service mysql stop
   mkdir -p /var/lib/mysql
 
-     if [ ! -d /var/lib/mysql/mysql ]; then
-        print_info "New Embedded Database Detected, setting up.."
-        cp -R /assets/config/var/lib/mysql/* /var/lib/mysql
-     fi
+  if [ ! -d /var/lib/mysql/mysql ]; then
+    print_info "New embedded database detected, setting up.."
+    cp -R /assets/config/var/lib/mysql/* /var/lib/mysql
+  fi
 
-  chown -R mysql:mysql /var/lib/mysql
+  chown -R mysql. /var/lib/mysql
   silent service mysql start
 fi
 

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -20,7 +20,7 @@ fi
 
 ### Startup
 if [ ! -f /data/.installed ]; then
-  print_notice "Creating Default Configuration Files"
+  print_notice "Creating default configuration files"
   mkdir -p /data/
   cp -R /assets/config/* /data/
 fi
@@ -33,7 +33,7 @@ if [ -f /data/etc/asterisk/.asterisk_version ]; then
   if [[ ${ASTERISK_VERSION_TMP//./} -lt "16" ]]; then
     print_error "****"
     print_error "***** This container has been detected to have FreePBX 14 installed"
-    print_error "***** You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 16"
+    print_error "***** You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 17"
     print_error "***** To continue using this image switch to using tiredofit/freepbx:14-latest"
     print_error "***** See https://github.com/tiredofit/docker-freepbx/issues/51 for more details"
     print_error "***** This container will now cease to function"
@@ -42,7 +42,7 @@ if [ -f /data/etc/asterisk/.asterisk_version ]; then
   fi
 fi
 
-print_notice "Setting File Permissions"
+print_notice "Setting file permissions"
 mkdir -p /data/etc/asterisk
 mkdir -p /data/var/lib/asterisk/{agi-bin,bin,playback}
 mkdir -p /data/var/spool/asterisk/{cache,dictate,meetme,monitor,recording,system,tmp,voicemail}
@@ -54,10 +54,10 @@ chown -R asterisk:asterisk /data
 
 ### Check if FreePBX Installed
 if [ ! -f $WEBROOT/admin/index.php ]; then
-    print_info "New Install Detected - Please wait while we fetch FreePBX - Will take 3 to 30 minutes!"
+    print_info "New install detected - please wait while we fetch FreePBX - Will take 3 to 30 minutes!"
 
   if [ "$WEBROOT" != "/var/www/html" ]; then
-    print_notice "Custom Installation Webroot Defined: '${WEBROOT}'"
+    print_notice "Custom installation webroot defined: '${WEBROOT}'"
   fi
 
   if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
@@ -101,7 +101,7 @@ EOF
     silent ./start_asterisk start
 
   if [ ! -f "/var/run/asterisk/asterisk.pid" ]; then
-    print_error "Can't seem to start Asterisk.. Exitting"
+    print_error "Can't seem to start Asterisk.. exiting"
     exit 1
   fi
 
@@ -141,12 +141,12 @@ EOF
   fi
 
   if [ ! -f "/usr/sbin/fwconsole" ]; then
-    print_error "Can't seem to locate /usr/sbin/fwconsole.. Exitting"
+    print_error "Can't seem to locate /usr/sbin/fwconsole.. exiting"
     exit 1
   fi
 
-  print_notice "Enabling Default Modules"
-  print_notice "Module Install: framework, core"
+  print_notice "Enabling default modules"
+  print_notice "Module install: framework, core"
   check_process
   silent fwconsole ma downloadinstall framework core
   sleep 3
@@ -161,26 +161,26 @@ EOF
     cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
     sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' $WEBROOT/admin/modules/cdr/install.php
     sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' $WEBROOT/admin/modules/cdr/install.php
-    print_notice '** [freepbx] Module Install: cdr'
+    print_notice '** [freepbx] Module install: cdr'
     check_process
     silent fwconsole ma install cdr
     cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
   else
-    print_notice "Module Install: cdr"
+    print_notice "Module install: cdr"
     check_process
     silent fwconsole ma install cdr
   fi
-    print_notice "Module Install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, music, sipsettings, voicemail "
+    print_notice "Module install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, music, sipsettings, voicemail "
     check_process
     silent fwconsole ma downloadinstall soundlang recordings voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
-    print_notice "Module Install: certman, userman, pm2"
+    print_notice "Module install: certman, userman, pm2"
     check_process
     silent fwconsole ma downloadinstall certman userman pm2
     silent fwconsole setting SHOWLANGUAGE 1
     silent fwconsole chown
     silent fwconsole reload
     chown -R asterisk. /home/asterisk/.npm
-    print_notice "Module Install: ucp"
+    print_notice "Module install: ucp"
     check_process
     # ucp fix https://community.freepbx.org/t/ucp-upgrade-error/58273
     touch /usr/bin/icu-config
@@ -194,32 +194,32 @@ EOF
       touch /var/log/mongodb/mongodb.log
       chown -R 777 /var/log/mongodb/mongodb.log
       mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf run &
-      print_notice "Module Install: xmpp"
+      print_notice "Module install: xmpp"
       check_process
       silent fwconsole ma downloadinstall xmpp
       print_notice "Stopping MongoDB"
       silent mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf --shutdown
     fi
     if [[ -v INSTALL_ADDITIONAL_MODULES ]] ; then
-      print_notice "Attempting to Install additional FreePBX Modules '${INSTALL_ADDITIONAL_MODULES}'"
+      print_notice "Attempting to install additional FreePBX modules '${INSTALL_ADDITIONAL_MODULES}'"
       modules=$(echo ${INSTALL_ADDITIONAL_MODULES} | tr "," "\n")
       for module in $modules
       do
-        print_notice "Module Install ${module}"
+        print_notice "Module install ${module}"
         silent fwconsole ma downloadinstall $module
       done
     fi
     silent fwconsole chown
     silent fwconsole reload
     silent fwconsole restart
-    print_info "Finished Installation of FreePBX Modules - Proceeding with next phase of install"
+    print_info "Finished installation of FreePBX modules - proceeding with next phase of install"
     silent fwconsole stop
     cd /
     rm -rf /usr/src/freepbx
 
   if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
       ### FOP2 Installation
-      print_info "Starting Installation of Flash Operator Panel 2"
+      print_info "Starting installation of Flash Operator Panel 2"
       silent fwconsole start
       mkdir -p /data/usr/local/fop2
       mkdir -p /var/log/apache2
@@ -276,7 +276,7 @@ fi
 
 if [ "$DB_EMBEDDED" = "FALSE" ];  then
 ### Setup Dynamic Configuration
-  print_notice "Setting Configuration"
+  print_notice "Setting configuration"
   cat <<EOF > /etc/freepbx.conf
 <?php
 \$amp_conf['AMPDBUSER'] = '$DB_USER';
@@ -332,7 +332,7 @@ chown asterisk:asterisk /etc/freepbx.conf
 
 if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
   ### Set RTP Ports
-  print_notice "Setting RTP Ports - Start: '${RTP_START}' Finish: '${RTP_FINISH}'"
+  print_notice "Setting RTP ports - start: '${RTP_START}' finish: '${RTP_FINISH}'"
   mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpstart","'$RTP_START'",1,0) ON DUPLICATE KEY UPDATE data="'$RTP_START'";INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpend","'$RTP_FINISH'",1,0) ON DUPLICATE KEY UPDATE data="'$RTP_FINISH'";'
   ### Fix a Freepbx bug with upgrades
   mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; ALTER TABLE featurecodes CHANGE column helptext helptext VARCHAR(10000);'
@@ -341,7 +341,7 @@ fi
 print_info "Starting Asterisk"
 
 if [ ! -f "/usr/sbin/fwconsole" ]; then
-  print_error "Can't seem to locate /usr/sbin/fwconsole.. Exitting. This is likely because the initial installation of FreePBX failed, and usually an upstream error. Try again by deleting all volumes and databases and starting from scratch before submitting an issue."
+  print_error "Can't seem to locate /usr/sbin/fwconsole.. Exiting. This is likely because the initial installation of FreePBX failed, and usually an upstream error. Try again by deleting all volumes and databases and starting from scratch before submitting an issue."
   exit 1
 fi
 
@@ -353,17 +353,17 @@ chown -R asterisk:asterisk /etc/amportal.conf
 
 ### Custom File Support
   if [ -d /assets/custom ] ; then
-     print_warn "Custom Files Found, Copying over top of Master.."
+     print_warn "Custom files found, copying over top of original.."
      cp -R /assets/custom/* /
      chown -R asterisk. /var/www/html/
      chown -R asterisk. /var/lib/asterisk
      chown -R asterisk. /var/spool/asterisk
   fi
 
-### Check to see if FOP Enabled and exists (Upgrade Catcher)
+### Check to see if FOP Enabled and exists (upgrade catcher)
 if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
     if [ ! -f /usr/local/fop2/fop2_server ] ; then
-      print_info "Installing Operator Panel"
+      print_info "Installing operator panel"
 
         ### FOP2 Installation
         silent fwconsole start
@@ -420,7 +420,7 @@ if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
   echo '    Alias "'$FOP_DIRECTORY'" "/var/www/html/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
 fi
 
-### Update CDR Hack Script
+### Update CDR hack script
 sed -i -e "s#<WEBROOT>#$WEBROOT#g" /usr/sbin/upgrade-cdr
 
 cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
@@ -439,7 +439,7 @@ if [ "$VIRTUAL_PROTO" = "https" ] || [ "$ENABLE_SSL" = "true" ] || [ "$ENABLE_SS
     print_notice "Enabling SSL"
 
     if [ ! -f /certs/${TLS_CERT} ] && [ ! -f /certs/${TLS_KEY} ]; then
-            print_warn "No SSL Certs found, Autogenerating SelfSigned - WebRTC will not work with a SelfSigned Certificate!"
+            print_warn "No SSL certs found, autogenerating self-signed - WebRTC will not work with a self-signed certificate!"
             cat <<EOF > /tmp/openssl.cnf
 [ req ]
 default_bits = 2048
@@ -550,7 +550,7 @@ fi
 
 ### FOP2 Setup
  if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-    print_info "Starting Operator Panel"
+    print_info "Starting operator panel"
     rm -rf /var/run/fop2.*
     mkdir -p /var/log/fop
     chown -R asterisk. /var/log/fop
@@ -561,9 +561,9 @@ fi
 silent service apache2 restart
 
 if [ "$UCP_FIRST" = "TRUE" ] ; then
-   print_info "Web Server Started - Container Initialization Complete - Visit your http(s)://yoursite/${ADMIN_DIRECTORY} to administer"
+   print_info "Web server started - container initialization completed - visit your http(s)://yoursite/${ADMIN_DIRECTORY} to administer"
 else
-   print_info "Web Server Started - Container Initialization Complete - Visit your http(s)://yoursite/ to administer"
+   print_info "Web server started - container initialization completed - visit your http(s)://yoursite/ to administer"
 fi
 
 liftoff

--- a/install/etc/cont-init.d/10-freepbx
+++ b/install/etc/cont-init.d/10-freepbx
@@ -1,39 +1,31 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="freepbx"
 
-## Embedded DB Variance
-if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
-   DB_EMBEDDED=TRUE
-else
-   DB_EMBEDDED=FALSE
-fi
-
-if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
+if var_false "$DB_EMBEDDED" ;  then
   sanity_db
-fi
-
-if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
   db_ready mariadb
 fi
 
 ### Startup
 if [ ! -f /data/.installed ]; then
   print_notice "Creating default configuration files"
-  mkdir -p /data/
+  mkdir -p /data
   cp -R /assets/config/* /data/
 fi
 
-### Container Version Sanity Check
+### Container version sanity check
 if [ -f /data/etc/asterisk/.asterisk_version ]; then
-  ASTERISK_VERSION_TMP=`cat /data/etc/asterisk/.asterisk_version`
+  ASTERISK_VERSION_TMP=$(cat /data/etc/asterisk/.asterisk_version)
   ASTERISK_VERSION_TMP=${ASTERISK_VERSION_TMP:0:2}
 
   if [[ ${ASTERISK_VERSION_TMP//./} -lt "16" ]]; then
     print_error "****"
     print_error "***** This container has been detected to have FreePBX 14 installed"
-    print_error "***** You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 17"
+    print_error "***** You cannot perform an inplace upgrade to FreePBX 15 and Asterisk 16+"
     print_error "***** To continue using this image switch to using tiredofit/freepbx:14-latest"
     print_error "***** See https://github.com/tiredofit/docker-freepbx/issues/51 for more details"
     print_error "***** This container will now cease to function"
@@ -44,23 +36,24 @@ fi
 
 print_notice "Setting file permissions"
 mkdir -p /data/etc/asterisk
-mkdir -p /data/var/lib/asterisk/{agi-bin,bin,playback}
-mkdir -p /data/var/spool/asterisk/{cache,dictate,meetme,monitor,recording,system,tmp,voicemail}
+mkdir -p /data/var/lib/asterisk/{bin,playback}
+mkdir -p /data/var/spool/asterisk/{backup,cache,dictate,fax,meetme,monitor,outgoing,recording,system,tmp,voicemail}
 mkdir -p /data/var/run/asterisk
 mkdir -p /data/home/asterisk
 mkdir -p /home/asterisk
 ln -sf /data/home/asterisk /home/asterisk && \
-chown -R asterisk:asterisk /data
+chown -R asterisk. /data
+chmod +x /usr/lib/asterisk/modules/*
 
-### Check if FreePBX Installed
-if [ ! -f $WEBROOT/admin/index.php ]; then
-    print_info "New install detected - please wait while we fetch FreePBX - Will take 3 to 30 minutes!"
+### Check if FreePBX installed
+if [ ! -f "$WEBROOT"/admin/index.php ]; then
+    print_info "New install detected - please wait while we fetch FreePBX - will take up to 30 minutes!"
 
   if [ "$WEBROOT" != "/var/www/html" ]; then
     print_notice "Custom installation webroot defined: '${WEBROOT}'"
   fi
 
-  if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
+  if var_false "$DB_EMBEDDED" ;  then
     cat <<EOF > /etc/odbc.ini
 [MySQL-asteriskcdrdb]
 Description = MySQL connection to 'asteriskcdrdb' database
@@ -85,27 +78,47 @@ option = 3
 EOF
   fi
 
-    cd /usr/src
-    mkdir -p /usr/src/freepbx
-    curl -ssL https://github.com/FreePBX/framework/archive/release/${FREEPBX_VERSION}.tar.gz| tar xfz - --strip 1 -C /usr/src/freepbx
+  cd /usr/src || exit
+  mkdir -p /usr/src/freepbx
+  curl -ssL https://github.com/FreePBX/framework/archive/release/"${FREEPBX_VERSION}".tar.gz| tar xfz - --strip 1 -C /usr/src/freepbx
 
-    silent sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80
-    silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/9F9169F4B33B4659.key
-    silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/3DDB2122FE6D84F7.key
-    silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/86CE877469D2EAD9.key
+  silent sudo -u asterisk gpg --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80
+  silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/9F9169F4B33B4659.key
+  silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/3DDB2122FE6D84F7.key
+  silent sudo -u asterisk gpg --import /usr/src/freepbx/amp_conf/htdocs/admin/libraries/BMO/86CE877469D2EAD9.key
 
-    cd /usr/src/freepbx
-    cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
-    touch /etc/asterisk/{modules,cdr}.conf
-    print_notice "Starting Asterisk ${ASTERISK_VERSION} for the first time"
-    silent ./start_asterisk start
+  cd /usr/src/freepbx || exit
+  cp -R /etc/odbc.ini /usr/src/freepbx/installlib/files/odbc.ini
+  touch /etc/asterisk/{acl,agents,amd,app_skel,ari,calendar,cdr,cdr_odbc,cel,cel_odbc,cel_tds,codecs,console,dundi,dongle,hep,modules,motif,ooh323,pjsip_wizard,pjproject,prometheus,res_parking,res_snmp.conf,res_stun_monitor,smdi,statsd,unistim,xmpp}.conf
+
+  if [ ! -f /etc/asterisk/extensions.lua ]; then
+    cat <<EOF > /etc/asterisk/extensions.lua
+extensions = {
+  ["internal"] = {
+    ["_1XX"] = function (context, extension)
+      app.dial('SIP/'..extension);
+
+      local dialstatus = channel["DIALSTATUS"]:get();
+      if dialstatus == 'BUSY' then
+        -- do something.......
+      elseif dialstatus == 'CHANUNAVAIL' then
+          -- do another thing
+          end;
+      end;
+  }
+}
+EOF
+  fi
+
+  print_notice "Starting Asterisk ${ASTERISK_VERSION} for the first time"
+  silent ./start_asterisk start
 
   if [ ! -f "/var/run/asterisk/asterisk.pid" ]; then
     print_error "Can't seem to start Asterisk.. exiting"
     exit 1
   fi
 
-  if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
+  if var_false "$DB_EMBEDDED" ;  then
     sed -i "s/'default' => 'localhost',/'default' => '$DB_HOST',/g" /usr/src/freepbx/installlib/installcommand.class.php
     sed -i -e "s/'default' => 'asteriskcdrdb',/'default' => '$DB_NAME',/g" /usr/src/freepbx/installlib/installcommand.class.php
     sed -i -e "s#\$amp_conf\['CDRDBNAME'\] = \$answers\['cdrdbname'\];#\$amp_conf\['CDRDBNAME'\] = '$DB_NAME';#g" /usr/src/freepbx/installlib/installcommand.class.php
@@ -113,13 +126,15 @@ EOF
 
   print_notice "Installing FreePBX source code"
 
-  if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
-    silent ./install -n --dbuser=$DB_USER --dbpass=$DB_PASS --dbname=$DB_NAME --cdrdbname=$DB_NAME --webroot=$WEBROOT
+  if var_false "$DB_EMBEDDED" ;  then
+    silent ./install -n --dbuser="$DB_USER" --dbpass="$DB_PASS" --dbname="$DB_NAME" --cdrdbname="$DB_NAME" --webroot="$WEBROOT"
   else
-    silent ./install -n --webroot=$WEBROOT
+    silent ./install -n --webroot="$WEBROOT"
   fi
 
-  if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
+  chown asterisk. /tmp/cron.error
+
+  if var_false "$DB_EMBEDDED" ;  then
     cat <<EOF > /etc/freepbx.conf
 <?php
 \$amp_conf['AMPDBUSER'] = '$DB_USER';
@@ -146,136 +161,138 @@ EOF
   fi
 
   print_notice "Enabling default modules"
-  print_notice "Module install: framework, core"
+  print_notice "Modules install: framework, core"
   check_process
   silent fwconsole ma downloadinstall framework core
   sleep 3
   silent check_process
   sleep 3
-  fwconsole ma download cdr
+  silent fwconsole ma download cdr
 
-  if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
-    # CDR Hack
-    mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT $DB_NAME < /usr/src/freepbx/installlib/SQL/cdr.sql
-    mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; UPDATE freepbx_settings SET `value` = "'$DB_HOST'" WHERE keyword = "CDRDBHOST"; UPDATE freepbx_settings SET `value` = "'$DB_NAME'" WHERE keyword = "CDRDBNAME"; UPDATE freepbx_settings SET `value` = "'$DB_PASS'" WHERE keyword = "CDRDBPASS"; UPDATE freepbx_settings SET `value` = "'$DB_USER'" WHERE keyword = "CDRDBUSER"; UPDATE freepbx_settings SET `value` = "mysql" WHERE keyword = "CDRDBTYPE"; UPDATE freepbx_settings SET `value` = "'$DB_PORT'" WHERE keyword = "CDRDBPORT"; UPDATE freepbx_settings SET `value` = "cdr" WHERE keyword = "CDRDBTABLENAME";'
-    cp -R $WEBROOT/admin/modules/cdr/install.php $WEBROOT/admin/modules/cdr/.install.php
-    sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' $WEBROOT/admin/modules/cdr/install.php
-    sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' $WEBROOT/admin/modules/cdr/install.php
+  if var_false "$DB_EMBEDDED" ;  then
+### CDR Hack
+    mysql -u"$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" "$DB_NAME" < /usr/src/freepbx/installlib/SQL/cdr.sql
+    # shellcheck disable=SC2016
+    mysql -u"$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e 'USE '"$DB_NAME"'; UPDATE freepbx_settings SET `value` = "'"$DB_HOST"'" WHERE keyword = "CDRDBHOST"; UPDATE freepbx_settings SET `value` = "'"$DB_NAME"'" WHERE keyword = "CDRDBNAME"; UPDATE freepbx_settings SET `value` = "'"$DB_PASS"'" WHERE keyword = "CDRDBPASS"; UPDATE freepbx_settings SET `value` = "'"$DB_USER"'" WHERE keyword = "CDRDBUSER"; UPDATE freepbx_settings SET `value` = "mysql" WHERE keyword = "CDRDBTYPE"; UPDATE freepbx_settings SET `value` = "'"$DB_PORT"'" WHERE keyword = "CDRDBPORT"; UPDATE freepbx_settings SET `value` = "cdr" WHERE keyword = "CDRDBTABLENAME";'
+    cp -R "$WEBROOT"/admin/modules/cdr/install.php "$WEBROOT"/admin/modules/cdr/.install.php
+    # shellcheck disable=SC2016
+    sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'"$DB_HOST"'";/g' "$WEBROOT"/admin/modules/cdr/install.php
+    # shellcheck disable=SC2016
+    sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'"$DB_NAME"'";/g' "$WEBROOT"/admin/modules/cdr/install.php
     print_notice '** [freepbx] Module install: cdr'
     check_process
     silent fwconsole ma install cdr
-    cp -R $WEBROOT/admin/modules/cdr/.install.php $WEBROOT/admin/modules/cdr/install.php
+    cp -R "$WEBROOT"/admin/modules/cdr/.install.php "$WEBROOT"/admin/modules/cdr/install.php
   else
-    print_notice "Module install: cdr"
+    print_notice "Module install: cdr (embedded db)"
     check_process
     silent fwconsole ma install cdr
   fi
-    print_notice "Module install: callrecordings, conferences, dashboard, featurecodeadmin, infoservices, logfiles, music, sipsettings, voicemail "
-    check_process
-    silent fwconsole ma downloadinstall soundlang recordings voicemail sipsettings infoservices featurecodeadmin logfiles conferences callrecording dashboard music
-    print_notice "Module install: certman, userman, pm2"
-    check_process
-    silent fwconsole ma downloadinstall certman userman pm2
-    silent fwconsole setting SHOWLANGUAGE 1
-    silent fwconsole chown
-    silent fwconsole reload
-    chown -R asterisk. /home/asterisk/.npm
-    print_notice "Module install: ucp"
-    check_process
-    # ucp fix https://community.freepbx.org/t/ucp-upgrade-error/58273
-    touch /usr/bin/icu-config
-    echo "icuinfo 2>/dev/null|grep \"version\"|sed 's/.*>\(.*\)<.*/\1/g'" > /usr/bin/icu-config
-    chmod +x /usr/bin/icu-config
-    silent fwconsole ma downloadinstall ucp
-    if [[ "$ENABLE_XMPP" = "TRUE" ]] || [[ "$ENABLE_XMPP" = "true" ]];  then
-      print_notice "Starting MongoDB temporarily"
-      mkdir -p /data/var/lib/mongodb
-      mkdir -p /var/log/mongodb
-      touch /var/log/mongodb/mongodb.log
-      chown -R 777 /var/log/mongodb/mongodb.log
-      mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf run &
-      print_notice "Module install: xmpp"
-      check_process
-      silent fwconsole ma downloadinstall xmpp
-      print_notice "Stopping MongoDB"
-      silent mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf --shutdown
-    fi
-    if [[ -v INSTALL_ADDITIONAL_MODULES ]] ; then
-      print_notice "Attempting to install additional FreePBX modules '${INSTALL_ADDITIONAL_MODULES}'"
-      modules=$(echo ${INSTALL_ADDITIONAL_MODULES} | tr "," "\n")
-      for module in $modules
-      do
-        print_notice "Module install ${module}"
-        silent fwconsole ma downloadinstall $module
-      done
-    fi
-    silent fwconsole chown
-    silent fwconsole reload
-    silent fwconsole restart
-    print_info "Finished installation of FreePBX modules - proceeding with next phase of install"
-    silent fwconsole stop
-    cd /
-    rm -rf /usr/src/freepbx
 
-  if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-      ### FOP2 Installation
-      print_info "Starting installation of Flash Operator Panel 2"
-      silent fwconsole start
-      mkdir -p /data/usr/local/fop2
-      mkdir -p /var/log/apache2
-      cd /usr/src
-      silent wget http://download.fop2.com/install_fop2.sh
-      chmod +x install_fop2.sh
-      silent ./install_fop2.sh
-      chown -R asterisk. /usr/local/fop2/
-      rm -rf /usr/src/*
-      silent service apache2 stop
-      silent service fop2 stop
-      silent fwconsole stop
-      chown -R asterisk. /usr/local/fop2/
+  print_notice "Modules install: backup, callrecording, conferences, dashboard, featurecodeadmin, filestore, fw_langpacks, infoservices, languages, logfiles, music, recordings, sipsettings, soundlang, voicemail"
+  check_process
+  silent fwconsole ma downloadinstall backup callrecording conferences dashboard featurecodeadmin filestore fw_langpacks infoservices languages logfiles music recordings sipsettings soundlang voicemail
+  print_notice "Modules install: certman, userman, pm2"
+  check_process
+  silent fwconsole ma downloadinstall certman userman pm2
+  silent fwconsole setting SHOWLANGUAGE 1
+  silent fwconsole chown
+  silent fwconsole reload
+  chown -R asterisk. /home/asterisk/.npm
+  print_notice "Module install: ucp"
+  check_process
+### UCP fix https://community.freepbx.org/t/ucp-upgrade-error/58273
+  touch /usr/bin/icu-config
+  echo "icuinfo 2>/dev/null|grep \"version\"|sed 's/.*>\(.*\)<.*/\1/g'" > /usr/bin/icu-config
+  chmod +x /usr/bin/icu-config
+  silent fwconsole ma downloadinstall ucp
+  if var_true "$ENABLE_XMPP" ;  then
+    print_notice "Starting MongoDB temporarily"
+    chown -R mongodb. /var/log/mongodb
+    rm -rf /var/run/mongodb/*
+    mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongod.conf run &
+    print_notice "Module install: xmpp"
+    check_process
+    silent fwconsole ma downloadinstall xmpp
+    sed -i -e "s/  uri: mongodb:\/\/localhost\/letschat/  uri: mongodb:\/\/localhost:27017\/letschat?useNewUrlParser=true/g" "$WEBROOT"/admin/modules/xmpp/node/node_modules/lets-chat/settings.yml
   fi
 
-    touch /data/.installed
-    echo $ASTERISK_VERSION > /etc/asterisk/.asterisk-version
+  if [[ -v INSTALL_ADDITIONAL_MODULES ]] ; then
+    print_notice "Attempting to install additional FreePBX modules '${INSTALL_ADDITIONAL_MODULES}'"
+    modules=$(echo "${INSTALL_ADDITIONAL_MODULES}" | tr "," "\n")
+    for module in $modules
+    do
+      print_notice "Module(s) install ${module}"
+      silent fwconsole ma downloadinstall "$module"
+    done
+  fi
+  silent fwconsole chown
+  silent fwconsole reload
+  silent fwconsole restart
+  print_info "Finished installation of FreePBX modules - proceeding with next phase of install"
+  silent fwconsole stop
+  cd /
+  rm -rf /usr/src/freepbx
+
+  if var_true "$ENABLE_FOP" ;  then
+### FOP2 Installation
+    print_info "Starting installation of Flash Operator Panel 2"
+    silent fwconsole start
+    mkdir -p /data/usr/local/fop2
+    mkdir -p /var/log/apache2
+    cd /usr/src || exit
+    silent wget http://download.fop2.com/install_fop2.sh
+    chmod +x install_fop2.sh
+    silent ./install_fop2.sh
+    chown -R asterisk. /usr/local/fop2
+    rm -rf /usr/src/*
+    silent service apache2 stop
+    silent service fop2 stop
+    silent fwconsole stop
+    chown -R asterisk. /usr/local/fop2
+  fi
+
+  touch /data/.installed
+  echo "$ASTERISK_VERSION" > /etc/asterisk/.asterisk-version
 fi
 
-### Data Persistence Workaround
-  if [ ! -f /usr/sbin/fwconsole ]; then
-       ln -s /var/lib/asterisk/bin/fwconsole /usr/sbin/fwconsole
-  fi
+### Data persistence workaround
+if [ ! -f /usr/sbin/fwconsole ]; then
+  ln -s /var/lib/asterisk/bin/fwconsole /usr/sbin/fwconsole
+fi
 
-  if [ ! -f /usr/sbin/amportal ]; then
-       ln -s /var/lib/asterisk/bin/amportal /usr/sbin/amportal
-  fi
+if [ ! -f /usr/sbin/amportal ]; then
+  ln -s /var/lib/asterisk/bin/amportal /usr/sbin/amportal
+fi
 
-  if [ ! -f /data/etc/amportal.conf ]; then
-      mkdir -p /data/etc/
-      cp -R /etc/amportal.conf /data/etc/
-      rm -rf /etc/amportal.conf
-      touch /data/etc/amportal.conf
-      chown asterisk:asterisk /data/etc/amportal.conf
-      ln -s /data/etc/amportal.conf /etc/amportal.conf
+if [ ! -f /data/etc/amportal.conf ]; then
+  mkdir -p /data/etc
+  cp -R /etc/amportal.conf /data/etc/
+  rm -rf /etc/amportal.conf
+  touch /data/etc/amportal.conf
+  chown asterisk. /data/etc/amportal.conf
+  ln -s /data/etc/amportal.conf /etc/amportal.conf
+else
+  ln -s /data/etc/amportal.conf /etc/amportal.conf
+  touch /data/etc/amportal.conf
+fi
+
+if var_true "$DB_EMBEDDED" ;  then
+  if [ ! -f /data/etc/freepbx.conf ]; then
+    mkdir -p /data/etc
+    cp -R /etc/freepbx.conf /data/etc/
+    rm -rf /etc/freepbx.conf
+    touch /data/etc/freepbx.conf
+    chown asterisk. /data/etc/freepbx.conf
+    ln -s /data/etc/freepbx.conf /etc/freepbx.conf
   else
-      ln -s /data/etc/amportal.conf /etc/amportal.conf
-      touch /data/etc/amportal.conf
+    ln -s /data/etc/freepbx.conf /etc/freepbx.conf
+    touch /data/etc/freepbx.conf
   fi
+fi
 
-  if [[ "$DB_EMBEDDED" = "TRUE" ]] || [[ "$DB_EMBEDDED" = "true" ]];  then
-      if [ ! -f /data/etc/freepbx.conf ]; then
-         mkdir -p /data/etc/
-         cp -R /etc/freepbx.conf /data/etc/
-         rm -rf /etc/freepbx.conf
-         touch /data/etc/freepbx.conf
-         chown asterisk:asterisk /data/etc/freepbx.conf
-         ln -s /data/etc/freepbx.conf /etc/freepbx.conf
-      else
-         ln -s /data/etc/freepbx.conf /etc/freepbx.conf
-         touch /data/etc/freepbx.conf
-      fi
-  fi
-
-if [ "$DB_EMBEDDED" = "FALSE" ];  then
-### Setup Dynamic Configuration
+if var_false "$DB_EMBEDDED" ;  then
+### Setup dynamic configuration
   print_notice "Setting configuration"
   cat <<EOF > /etc/freepbx.conf
 <?php
@@ -328,14 +345,14 @@ loguniqueid=yes
 EOF
 fi
 
-chown asterisk:asterisk /etc/freepbx.conf
+chown asterisk. /etc/freepbx.conf
 
-if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then
-  ### Set RTP Ports
-  print_notice "Setting RTP ports - start: '${RTP_START}' finish: '${RTP_FINISH}'"
-  mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpstart","'$RTP_START'",1,0) ON DUPLICATE KEY UPDATE data="'$RTP_START'";INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpend","'$RTP_FINISH'",1,0) ON DUPLICATE KEY UPDATE data="'$RTP_FINISH'";'
-  ### Fix a Freepbx bug with upgrades
-  mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; ALTER TABLE featurecodes CHANGE column helptext helptext VARCHAR(10000);'
+### Set RTP ports and fix a FreePBX bug with upgrades
+print_notice "Setting RTP ports - start: '${RTP_START}' finish: '${RTP_FINISH}'"
+if var_false "$DB_EMBEDDED" ;  then
+  mysql -u"$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e 'USE '"$DB_NAME"'; ALTER TABLE featurecodes CHANGE column helptext helptext VARCHAR(10000); INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpstart","'"$RTP_START"'",1,0) ON DUPLICATE KEY UPDATE data="'"$RTP_START"'";INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpend","'"$RTP_FINISH"'",1,0) ON DUPLICATE KEY UPDATE data="'"$RTP_FINISH"'";'
+else
+  mysql -e 'USE asterisk; ALTER TABLE featurecodes CHANGE column helptext helptext VARCHAR(10000); INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpstart","'"$RTP_START"'",1,0) ON DUPLICATE KEY UPDATE data="'"$RTP_START"'";INSERT INTO sipsettings (keyword, data, seq, type) VALUES ("rtpend","'"$RTP_FINISH"'",1,0) ON DUPLICATE KEY UPDATE data="'"$RTP_FINISH"'";'
 fi
 
 print_info "Starting Asterisk"
@@ -348,40 +365,47 @@ fi
 silent fwconsole chown
 silent fwconsole start
 silent fwconsole reload
-chown -R asterisk /etc/asterisk/*
-chown -R asterisk:asterisk /etc/amportal.conf
+chown -R asterisk. /etc/asterisk
+chown asterisk. /etc/amportal.conf
 
-### Custom File Support
+### Custom file support
   if [ -d /assets/custom ] ; then
      print_warn "Custom files found, copying over top of original.."
      cp -R /assets/custom/* /
-     chown -R asterisk. /var/www/html/
+     chown -R asterisk. /var/www/html
      chown -R asterisk. /var/lib/asterisk
      chown -R asterisk. /var/spool/asterisk
   fi
 
-### Check to see if FOP Enabled and exists (upgrade catcher)
-if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-    if [ ! -f /usr/local/fop2/fop2_server ] ; then
-      print_info "Installing operator panel"
+### Check to see if FOP enabled and exists (upgrade catcher)
+if var_true "$ENABLE_FOP" ;  then
+  if [ ! -f /usr/local/fop2/fop2_server ] ; then
+    print_info "Installing operator panel"
 
-        ### FOP2 Installation
-        silent fwconsole start
-        mkdir -p /data/usr/local/fop2
-        mkdir -p /var/log/apache2
-        cd /usr/src
-        silent wget http://download.fop2.com/install_fop2.sh
-        chmod +x install_fop2.sh
-        silent ./install_fop2.sh
-        chown -R asterisk. /usr/local/fop2/
-        rm -rf /usr/src/*
-        silent service apache2 stop
-        silent service fop2 stop
-        silent fwconsole stop
-    fi
+### FOP2 installation
+    silent fwconsole start
+    mkdir -p /data/usr/local/fop2
+    mkdir -p /var/log/apache2
+    cd /usr/src || exit
+    silent wget http://download.fop2.com/install_fop2.sh
+    chmod +x install_fop2.sh
+    silent ./install_fop2.sh
+    chown -R asterisk. /usr/local/fop2
+    rm -rf /usr/src/*
+    silent service apache2 stop
+    silent service fop2 stop
+    silent fwconsole stop
+  fi
 fi
 
-### Apache Setup
+if var_true "$ENABLE_XMPP" ; then
+  print_notice "Stopping MongoDB"
+  silent mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongod.conf --shutdown
+fi
+
+chown -R asterisk. /var/spool/asterisk
+
+### Apache setup
 cat >> /etc/apache2/conf-available/allowoverride.conf << EOF
 <Directory $WEBROOT>
     AllowOverride All
@@ -408,16 +432,17 @@ ErrorLog /dev/null
 <VirtualHost *:$HTTP_PORT>
 EOF
 
-if [ "$UCP_FIRST" = "TRUE" ] || [ "$UCP_FIRST" = "true" ] ; then
-  echo "    DocumentRoot "$WEBROOT"/ucp" >> /etc/apache2/sites-enabled/000-default.conf
-  echo '    Alias "'$ADMIN_DIRECTORY'" "'$WEBROOT'/admin"' >> /etc/apache2/sites-enabled/000-default.conf
-  echo '    Alias "/ucp" "'$WEBROOT'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
+if var_true "$UCP_FIRST" ; then
+  # shellcheck disable=SC2129
+  echo '    DocumentRoot "'"$WEBROOT"'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
+  echo '    Alias "'"$ADMIN_DIRECTORY"'" "'"$WEBROOT"'/admin"' >> /etc/apache2/sites-enabled/000-default.conf
+  echo '    Alias "/ucp" "'"$WEBROOT"'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
 else
-  echo "    DocumentRoot "$WEBROOT >> /etc/apache2/sites-enabled/000-default.conf
+  echo "    DocumentRoot ""$WEBROOT" >> /etc/apache2/sites-enabled/000-default.conf
 fi
 
-if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-  echo '    Alias "'$FOP_DIRECTORY'" "/var/www/html/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
+if var_true "$ENABLE_FOP" ;  then
+  echo '    Alias "'"$FOP_DIRECTORY"'" "/var/www/html/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
 fi
 
 ### Update CDR hack script
@@ -435,12 +460,12 @@ cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
 </VirtualHost>
 EOF
 
-if [ "$VIRTUAL_PROTO" = "https" ] || [ "$ENABLE_SSL" = "true" ] || [ "$ENABLE_SSL" = "TRUE" ] ;  then
-    print_notice "Enabling SSL"
+if [ "$VIRTUAL_PROTO" = "https" ] || var_true "$ENABLE_SSL" ;  then
+  print_notice "Enabling SSL"
 
-    if [ ! -f /certs/${TLS_CERT} ] && [ ! -f /certs/${TLS_KEY} ]; then
-            print_warn "No SSL certs found, autogenerating self-signed - WebRTC will not work with a self-signed certificate!"
-            cat <<EOF > /tmp/openssl.cnf
+  if [ ! -f /certs/"${TLS_CERT}" ] && [ ! -f /certs/"${TLS_KEY}" ]; then
+    print_warn "No SSL certs found, autogenerating self-signed - WebRTC will not work with a self-signed certificate!"
+    cat <<EOF > /tmp/openssl.cnf
 [ req ]
 default_bits = 2048
 encrypt_key = yes
@@ -455,7 +480,7 @@ L=Self Signed
 O=Freepbx
 OU=Freepbx
 CN=*
-emailAddress=selfsigned@example.com
+emailAddress=hostmaster@local
 
 [ cert_type ]
 nsCertType = server
@@ -466,10 +491,10 @@ EOF
     rm -rf /tmp/openssl.cnf
     TLS_CERT="cert.pem"
     TLS_KEY="key.pem"
-    fi
+  fi
 
-    silent a2enmod ssl
-    cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
+  silent a2enmod ssl
+  cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
 <VirtualHost *:$HTTPS_PORT>
     SSLEngine on
     SSLCertificateFile "/certs/$TLS_CERT"
@@ -478,21 +503,22 @@ EOF
     CustomLog /var/log/apache2/access.log common
 EOF
 
-if [ "$UCP_FIRST" = "TRUE" ] || [ "$UCP_FIRST" = "true" ] ; then
-  echo "    DocumentRoot "$WEBROOT"/ucp" >> /etc/apache2/sites-enabled/000-default.conf
-  echo '    Alias "'$ADMIN_DIRECTORY'" "'$WEBROOT'/admin"' >> /etc/apache2/sites-enabled/000-default.conf
-  echo '    Alias "/ucp" "'$WEBROOT'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
-else
-  echo "    DocumentRoot $WEBROOT" >> /etc/apache2/sites-enabled/000-default.conf
-fi
+  if var_true "$UCP_FIRST" ; then
+    # shellcheck disable=SC2129
+    echo '    DocumentRoot "'"$WEBROOT"'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
+    echo '    Alias "'"$ADMIN_DIRECTORY"'" "'"$WEBROOT"'/admin"' >> /etc/apache2/sites-enabled/000-default.conf
+    echo '    Alias "/ucp" "'"$WEBROOT"'/ucp"' >> /etc/apache2/sites-enabled/000-default.conf
+  else
+    echo "    DocumentRoot $WEBROOT" >> /etc/apache2/sites-enabled/000-default.conf
+  fi
 
-if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-  echo '    Alias "'$FOP_DIRECTORY'" "'$WEBROOT'/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
-  sed -i -e 's#ssl_certificate_file=.*#ssl_certificate_file=/certs/'$TLS_CERT'#g' /usr/local/fop2/fop2.cfg
-  sed -i -e 's#ssl_certificate_key_file=.*#ssl_certificate_key_file=/certs/'$TLS_KEY'#g' /usr/local/fop2/fop2.cfg
-fi
+  if var_true "$ENABLE_FOP" ;  then
+    echo '    Alias "'"$FOP_DIRECTORY"'" "'"$WEBROOT"'/fop2"' >>/etc/apache2/sites-enabled/000-default.conf
+    sed -i -e 's#ssl_certificate_file=.*#ssl_certificate_file=/certs/'$TLS_CERT'#g' /usr/local/fop2/fop2.cfg
+    sed -i -e 's#ssl_certificate_key_file=.*#ssl_certificate_key_file=/certs/'$TLS_KEY'#g' /usr/local/fop2/fop2.cfg
+  fi
 
-cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
+  cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
     <Location /server-status>
     SetHandler server-status
     Order deny,allow
@@ -503,7 +529,7 @@ cat >> /etc/apache2/sites-enabled/000-default.conf << EOF
 EOF
 fi
 
-# Write ports.conf
+### Write ports.conf
 cat > /etc/apache2/ports.conf <<EOF
 Listen $HTTP_PORT
 
@@ -535,32 +561,32 @@ chown -R root:adm /var/log/apache2
 chown asterisk. /run/lock/apache2
 chown -R asterisk. /usr/local/fop2
 
-### Disable Indexes if outside of regular webroot
+### Disable indexes if outside of regular webroot
 if [ "$WEBROOT" != "/var/www/html" ]; then
   silent a2dismod autoindex -f
 fi
 
-### SMTP Config
- if [ "$ENABLE_SMTP" = "TRUE" ] || [ "$ENABLE_SMTP" = "true" ];  then
-   echo 'sendmail_path="/usr/bin/msmtp -C /etc/msmtprc -t "' > /etc/php/5.6/apache2/conf.d/smtp.ini
-   echo 'sendmail_path="/usr/bin/msmtp -C /etc/msmtprc -t "' > /etc/php/5.6/cli/conf.d/smtp.ini
-   chown asterisk:asterisk /etc/msmtprc
-   chmod 600 /etc/msmtprc
- fi
+### SMTP config
+if var_true "$ENABLE_SMTP" ;  then
+  echo 'sendmail_path="/usr/bin/msmtp -C /etc/msmtprc -t "' > /etc/php/"${PHP_VERSION}"/apache2/conf.d/smtp.ini
+  echo 'sendmail_path="/usr/bin/msmtp -C /etc/msmtprc -t "' > /etc/php/"${PHP_VERSION}"/cli/conf.d/smtp.ini
+  chown asterisk. /etc/msmtprc
+  chmod 0600 /etc/msmtprc
+fi
 
-### FOP2 Setup
- if [ "$ENABLE_FOP" = "TRUE" ] || [ "$ENABLE_FOP" = "true" ];  then
-    print_info "Starting operator panel"
-    rm -rf /var/run/fop2.*
-    mkdir -p /var/log/fop
-    chown -R asterisk. /var/log/fop
-    sed -i -e "s#manager_host=.*#manager_host=127.0.0.1#g" /usr/local/fop2/fop2.cfg
-    /usr/local/fop2/fop2_server -d --logdir /var/log/fop
- fi
+### FOP2 setup
+if var_true "$ENABLE_FOP" ;  then
+  print_info "Starting operator panel"
+  rm -rf /var/run/fop2.*
+  mkdir -p /var/log/fop
+  chown -R asterisk. /var/log/fop
+  sed -i -e "s#manager_host=.*#manager_host=127.0.0.1#g" /usr/local/fop2/fop2.cfg
+  /usr/local/fop2/fop2_server -d --logdir /var/log/fop
+fi
 
 silent service apache2 restart
 
-if [ "$UCP_FIRST" = "TRUE" ] ; then
+if var_true "$UCP_FIRST" ; then
    print_info "Web server started - container initialization completed - visit your http(s)://yoursite/${ADMIN_DIRECTORY} to administer"
 else
    print_info "Web server started - container initialization completed - visit your http(s)://yoursite/ to administer"

--- a/install/etc/fail2ban/filter.d/freepbx.conf
+++ b/install/etc/fail2ban/filter.d/freepbx.conf
@@ -5,5 +5,3 @@
 failregex = .* Authentication failure for .* from <HOST>\.
 
 ignoreregex =
-
-

--- a/install/etc/s6/services/08-mongodb/run
+++ b/install/etc/s6/services/08-mongodb/run
@@ -1,9 +1,12 @@
 #!/usr/bin/with-contenv bash
 
-for s in /assets/functions/*; do source $s; done
+# shellcheck disable=SC1090
+for s in /assets/functions/*; do source "$s"; done
+# shellcheck disable=SC2034
 PROCESS_NAME="mongo"
+
 check_container_initialized
 check_service_initialized init
-chown -R 777 /var/log/mongodb
+chown -R mongodb. /var/log/mongodb
 rm -rf /var/run/mongodb/*
-exec mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongodb.conf run
+exec mongod --unixSocketPrefix=/var/run/mongodb --config /etc/mongod.conf run

--- a/install/usr/sbin/upgrade-cdr
+++ b/install/usr/sbin/upgrade-cdr
@@ -1,16 +1,18 @@
 #!/usr/bin/with-contenv /bin/bash
 
-if [[ "$DB_EMBEDDED" = "FALSE" ]] || [[ "$DB_EMBEDDED" = "false" ]];  then  
-	## This is a dirty hack to allow for updating the CDR Module to use a seperate DB Host and the same DB as FreePBX.
-		echo '** [freepbx] Performing Manual Upgrade of CDR Module'
-		cp -R <WEBROOT>/admin/modules/cdr/install.php <WEBROOT>/admin/modules/cdr/.install.php
-		sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'$DB_HOST'";/g' <WEBROOT>/admin/modules/cdr/install.php
-		sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'$DB_NAME'";/g' <WEBROOT>/admin/modules/cdr/install.php
-		fwconsole ma upgrade cdr
-		cp -R <WEBROOT>/admin/modules/cdr/.install.php <WEBROOT>/admin/modules/cdr/install.php
-		fwconsole chown 
-    	fwconsole reload
-    	chown -R asterisk /etc/asterisk
+if var_false "$DB_EMBEDDED" ;  then
+  ## This is a dirty hack to allow for updating the CDR Module to use a seperate DB Host and the same DB as FreePBX.
+	echo '** [freepbx] Performing Manual Upgrade of CDR Module'
+	cp -R "$WEBROOT"/admin/modules/cdr/install.php "$WEBROOT"/admin/modules/cdr/.install.php
+	# shellcheck disable=SC2016
+	sed -i -e 's/\$db_host = !empty(\$db_host) ? \$db_host : "localhost";/\$db_host = !empty(\$db_host) ? \$db_host : "'"$DB_HOST"'";/g' <WEBROOT>/admin/modules/cdr/install.php
+	# shellcheck disable=SC2016
+	sed -i -e 's/\$db_name = !empty(\$db_name) ? \$db_name : "asteriskcdrdb";/\$db_name = !empty(\$db_name) ? \$db_name : "'"$DB_NAME"'";/g' <WEBROOT>/admin/modules/cdr/install.php
+	fwconsole ma upgrade cdr
+	cp -R "$WEBROOT"/admin/modules/cdr/.install.php "$WEBROOT"/admin/modules/cdr/install.php
+	fwconsole chown
+  fwconsole reload
+  chown -R asterisk. /etc/asterisk
 else
-		echo '** [freepbx] There is no need for you to run this script as you are using the embedded database'
+	echo '** [freepbx] There is no need for you to run this script as you are using the embedded database'
 fi

--- a/install/usr/sbin/upgrade-core
+++ b/install/usr/sbin/upgrade-core
@@ -3,9 +3,9 @@
 DB_PORT=${DB_PORT:-"3306"}
 ## When updating core or the framework modules, FreePBX will fail due to the in the `featurecodes` table `helptext` column being corrupt. This is a simple script to update FreePBX framework and core modules
 
-mysql -u$DB_USER -p$DB_PASS -h$DB_HOST -P$DB_PORT -e 'USE '$DB_NAME'; UPDATE featurecodes SET helptext =  "";'
+mysql -u"$DB_USER" -p"$DB_PASS" -h"$DB_HOST" -P"$DB_PORT" -e 'USE '"$DB_NAME"'; UPDATE featurecodes SET helptext =  "";'
 fwconsole ma upgrade framework
 fwconsole ma upgrade core
 fwconsole chown 
 fwconsole reload
-chown -R asterisk /etc/asterisk
+chown -R asterisk. /etc/asterisk

--- a/install/usr/sbin/upgrade-core
+++ b/install/usr/sbin/upgrade-core
@@ -9,4 +9,3 @@ fwconsole ma upgrade core
 fwconsole chown 
 fwconsole reload
 chown -R asterisk /etc/asterisk
-


### PR DESCRIPTION
 - Asterisk version 17.4.0 support
 - FreePBX version 15.0.16.55 support
 - ODBC for MariaDB install from Debian repository
 - using var_true/var_false and other stuff from base repo
 - MongoDB startup script fixed
 - MariaDB startup script fixed
 - Changed `` to $() (deprecated)
 - Add agi-bin, backup, fax and outgoing directory in script
 - Files in asterisk modules directory with execute bit now
 - Touch additional config files in /etc/asterisk
 - /tmp/cron.error privileges fixed
 - Added new modules in default state: backup, filestore, fw_langpacks, languages
 - XMPP support fixed
 - Set RTP range ports in DB_EMBEDDED too
 - extend featurecodes helptext column in DB_EMBEDDED too
 - Privileges in FreePBX doctrine cache fixed
 - BCG729 versioning support
 - G72X versioning and cpu family support
 - Added chan_dongle support (USB Huawei modem)
 - MongoDB versioning support
 - PHP5.6 to 7.3 support
 - ENABLE_CRON, ENABLE_SMTP now TRUE
 - More features support in ASTERISK image
 - Small fixes in docs