### PR TITLE
Bumped Asterisk version to 17.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tiredofit/nodejs:10-debian
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Set defaults
-ENV ASTERISK_VERSION=17.9.3 \
+ENV ASTERISK_VERSION=17.9.4 \
     BCG729_VERSION=1.0.4 \
     DONGLE_VERSION=20200610 \
     G72X_CPUHOST=penryn \
@@ -84,7 +84,6 @@ RUN echo "Package: libxml2*" > /etc/apt/preferences.d/libxml2 && \
                         libvpb-dev \
                         libxml2-dev \
                         libxslt1-dev \
-                        linux-headers \
                         portaudio19-dev \
                         python-dev \
                         subversion \


### PR DESCRIPTION
Fixed build_deps ('linux-headers' obsolete)