### PR TITLE
(Dockerfile) update-alternatives should use correct PHP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ RUN echo "Package: libxml2*" > /etc/apt/preferences.d/libxml2 && \
     mkdir -p /var/log/asterisk && \
     mkdir -p /var/log/apache2 && \
     mkdir -p /var/log/httpd && \
-    update-alternatives --set php /usr/bin/php5.6 && \
+    update-alternatives --set php /usr/bin/php${PHP_VERSION} && \
     \
 ### Zabbix setup
     echo '%zabbix ALL=(asterisk) NOPASSWD:/usr/sbin/asterisk' >> /etc/sudoers && \


### PR DESCRIPTION
In the current Dockerfile, update alternatives specified php5.6, rather than using variable PHP_VERSION which was set, causing the variable to be useless for version changes.